### PR TITLE
Improve auto updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: update
         run: |
-          nix-build -A pkgs.npins
-          result/bin/npins update nixpkgs
+          nix-build -A autoPrUpdate
+          result/bin/auto-pr-update > body
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -23,4 +23,4 @@ jobs:
           commit-message: "Automated Nixpkgs update"
           branch: auto-nixpkgs-update
           title: "Automated Nixpkgs update"
-          body: "Update the pinned Nixpkgs automatically"
+          body-path: body

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,6 +25,8 @@ jobs:
           # and https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork
           token: ${{ secrets.MACHINE_USER_PAT }}
           push-to-fork: infinixbot/nixpkgs-check-by-name
+          committer: infinixbot <infinixbot@infinisil.com>
+          author: infinixbot <infinixbot@infinisil.com>
           commit-message: "Automated update"
           branch: auto-update
           title: "Automated update"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "Automated Nixpkgs update"
-          branch: auto-nixpkgs-update
-          title: "Automated Nixpkgs update"
+          commit-message: "Automated update"
+          branch: auto-update
+          title: "Automated update"
           body-path: body

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          # To trigger CI for automated PRs, we use a separate machine account
+          # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+          # and https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork
+          token: ${{ secrets.MACHINE_USER_PAT }}
+          push-to-fork: infinixbot/nixpkgs-check-by-name
           commit-message: "Automated update"
           branch: auto-update
           title: "Automated update"

--- a/default.nix
+++ b/default.nix
@@ -62,7 +62,7 @@ build // {
     text =
       let
         commands = [
-          "npins update nixpkgs"
+          "npins update"
         ];
       in
       ''

--- a/default.nix
+++ b/default.nix
@@ -58,11 +58,13 @@ build // {
     name = "auto-pr-update";
     runtimeInputs = with pkgs; [
       npins
+      cargo
     ];
     text =
       let
         commands = [
           "npins update"
+          "cargo update"
         ];
       in
       ''

--- a/default.nix
+++ b/default.nix
@@ -53,6 +53,28 @@ build // {
     ];
   };
 
+  # Run regularly by CI and turned into a PR
+  autoPrUpdate = pkgs.writeShellApplication {
+    name = "auto-pr-update";
+    runtimeInputs = with pkgs; [
+      npins
+    ];
+    text =
+      let
+        commands = [
+          "npins update nixpkgs"
+        ];
+      in
+      ''
+        echo "Run automated updates"
+      ''
+      + pkgs.lib.concatMapStrings (command: ''
+        echo -e '<details><summary>${command}</summary>\n\n```'
+        ${command} 2>&1
+        echo -e '```\n</details>'
+      '') commands;
+  };
+
   # Tests the tool on the pinned Nixpkgs tree, this is a good sanity check
   checks.nixpkgs = pkgs.runCommand "test-nixpkgs-check-by-name" {
     nativeBuildInputs = [


### PR DESCRIPTION
Improves upon the automated update PRs introduced in #12 to resolve issues brought up in the first automated PR #14 

- Give more information about the updates, not much, but at least the output of `npins update`
- Update all `npins` sources, not just Nixpkgs.
- Also run a `cargo update`
- Make it trigger CI by using an unprivileged separate machine account (welcome, @infinixbot!)
- Set committer and author of the commits to the machine account