### PR TITLE
Set `GH_TOKEN` to fix automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,5 @@ jobs:
 
       - name: release
         run: scripts/release.sh
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Hopefully..

See https://github.com/NixOS/nixpkgs-check-by-name/actions/runs/8381658441/job/22953710054#step:4:575 for the failure and #16 for where this was introduced