### PR TITLE
Fix updates (another try)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: cachix/install-nix-action@v26
 
       - name: build
-        run: nix-build -A build -A shell -A checks
+        run: nix-build -A ci

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: update
         run: |
           nix-build repo -A autoPrUpdate
-          result/bin/auto-pr-update > body
+          result/bin/auto-pr-update repo > body
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/default.nix
+++ b/default.nix
@@ -56,19 +56,22 @@ let
       ];
       text =
         let
-          commands = [
-            "npins update"
-            "cargo update"
-          ];
+          commands = {
+            "npins changes" = ''
+              npins update --directory "$REPO_ROOT/npins"'';
+            "cargo changes" = ''
+              cargo update --manifest-path "$REPO_ROOT/Cargo.toml"'';
+          };
         in
         ''
+          REPO_ROOT=$1
           echo "Run automated updates"
         ''
-        + pkgs.lib.concatMapStrings (command: ''
-          echo -e '<details><summary>${command}</summary>\n\n```'
+        + pkgs.lib.concatStrings (pkgs.lib.mapAttrsToList (title: command: ''
+          echo -e '<details><summary>${title}</summary>\n\n```'
           ${command} 2>&1
           echo -e '```\n</details>'
-        '') commands;
+        '') commands);
     };
 
     # Tests the tool on the pinned Nixpkgs tree, this is a good sanity check

--- a/default.nix
+++ b/default.nix
@@ -30,63 +30,68 @@ let
     nix-store --init
   '';
 
-  build = pkgs.callPackage ./package.nix {
-    inherit nixpkgsLibPath initNix runtimeExprPath testNixpkgsPath;
+
+  results = {
+    build = pkgs.callPackage ./package.nix {
+      inherit nixpkgsLibPath initNix runtimeExprPath testNixpkgsPath;
+    };
+
+    shell = pkgs.mkShell {
+      env.NIX_CHECK_BY_NAME_EXPR_PATH = toString runtimeExprPath;
+      env.NIX_PATH = "test-nixpkgs=${toString testNixpkgsPath}:test-nixpkgs/lib=${toString nixpkgsLibPath}";
+      env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+      inputsFrom = [ results.build ];
+      nativeBuildInputs = with pkgs; [
+        npins
+        rust-analyzer
+      ];
+    };
+
+    # Run regularly by CI and turned into a PR
+    autoPrUpdate = pkgs.writeShellApplication {
+      name = "auto-pr-update";
+      runtimeInputs = with pkgs; [
+        npins
+        cargo
+      ];
+      text =
+        let
+          commands = [
+            "npins update"
+            "cargo update"
+          ];
+        in
+        ''
+          echo "Run automated updates"
+        ''
+        + pkgs.lib.concatMapStrings (command: ''
+          echo -e '<details><summary>${command}</summary>\n\n```'
+          ${command} 2>&1
+          echo -e '```\n</details>'
+        '') commands;
+    };
+
+    # Tests the tool on the pinned Nixpkgs tree, this is a good sanity check
+    nixpkgsCheck = pkgs.runCommand "test-nixpkgs-check-by-name" {
+      nativeBuildInputs = [
+        results.build
+        pkgs.nix
+      ];
+      nixpkgsPath = nixpkgs;
+    } ''
+      ${initNix}
+      nixpkgs-check-by-name --base "$nixpkgsPath" "$nixpkgsPath"
+      touch $out
+    '';
   };
 
 in
-build // {
+results.build // results // {
 
-  inherit build;
-
-  # Used by CI and good for debugging
+  # Good for debugging
   inherit pkgs;
 
-  shell = pkgs.mkShell {
-    env.NIX_CHECK_BY_NAME_EXPR_PATH = toString runtimeExprPath;
-    env.NIX_PATH = "test-nixpkgs=${toString testNixpkgsPath}:test-nixpkgs/lib=${toString nixpkgsLibPath}";
-    env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
-    inputsFrom = [ build ];
-    nativeBuildInputs = with pkgs; [
-      npins
-      rust-analyzer
-    ];
-  };
+  # Built by CI
+  ci = pkgs.linkFarm "ci" results;
 
-  # Run regularly by CI and turned into a PR
-  autoPrUpdate = pkgs.writeShellApplication {
-    name = "auto-pr-update";
-    runtimeInputs = with pkgs; [
-      npins
-      cargo
-    ];
-    text =
-      let
-        commands = [
-          "npins update"
-          "cargo update"
-        ];
-      in
-      ''
-        echo "Run automated updates"
-      ''
-      + pkgs.lib.concatMapStrings (command: ''
-        echo -e '<details><summary>${command}</summary>\n\n```'
-        ${command} 2>&1
-        echo -e '```\n</details>'
-      '') commands;
-  };
-
-  # Tests the tool on the pinned Nixpkgs tree, this is a good sanity check
-  checks.nixpkgs = pkgs.runCommand "test-nixpkgs-check-by-name" {
-    nativeBuildInputs = [
-      build
-      pkgs.nix
-    ];
-    nixpkgsPath = nixpkgs;
-  } ''
-    ${initNix}
-    nixpkgs-check-by-name --base "$nixpkgsPath" "$nixpkgsPath"
-    touch $out
-  '';
 }


### PR DESCRIPTION
Addresses the previous problem (https://github.com/NixOS/nixpkgs-check-by-name/pull/20#issuecomment-2013998832) with the second commit.

Also using this opportunity to improve how we define what CI should build and make it build the automated update script (but not running it), see the first commit for that.

This makes sure that when we make changes to the update script (like in this PR), it at least gets at least built (though not ran).