### PR TITLE
Refactor Error Types

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -352,7 +352,7 @@ fn by_name_override(
     location: Location,
     relative_location_file: RelativePathBuf,
 ) -> validation::Validation<ratchet::RatchetState<ratchet::ManualDefinition>> {
-    let to_problem = |kind| -> NixpkgsProblem {
+    let to_problem = |kind| {
         NixpkgsProblem::ByNameOverrideProblem(ByNameOverrideError {
             package_name: attribute_name.to_owned(),
             file: relative_location_file,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,9 +1,7 @@
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::nixpkgs_problem::ByNameError;
-use crate::nixpkgs_problem::ByNameErrorKind;
-use crate::nixpkgs_problem::ByNameOverrideError;
-use crate::nixpkgs_problem::ByNameOverrideErrorKind;
-use crate::nixpkgs_problem::NixpkgsProblem;
+use crate::nixpkgs_problem::{
+    ByNameError, ByNameErrorKind, ByNameOverrideError, ByNameOverrideErrorKind, NixpkgsProblem,
+};
 use crate::ratchet;
 use crate::ratchet::RatchetState::Loose;
 use crate::ratchet::RatchetState::Tight;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -218,7 +218,7 @@ fn by_name(
     use ByNameAttribute::*;
 
     let to_problem = |kind| {
-        NixpkgsProblem::ByNameProblem(ByNameError {
+        NixpkgsProblem::ByName(ByNameError {
             attribute_name: attribute_name.to_owned(),
             kind,
         })
@@ -347,7 +347,7 @@ fn by_name_override(
     relative_location_file: RelativePathBuf,
 ) -> validation::Validation<ratchet::RatchetState<ratchet::ManualDefinition>> {
     let to_problem = |kind| {
-        NixpkgsProblem::ByNameOverrideProblem(ByNameOverrideError {
+        NixpkgsProblem::ByNameOverride(ByNameOverrideError {
             package_name: attribute_name.to_owned(),
             file: relative_location_file,
             line: location.line,

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -19,7 +19,7 @@ pub enum NixpkgsProblem {
         shard_name: String,
     },
     PackageNonDir {
-        relative_package_dir: RelativePathBuf,
+        package_name: String,
     },
     CaseSensitiveDuplicate {
         relative_shard_path: RelativePathBuf,
@@ -156,11 +156,13 @@ impl fmt::Display for NixpkgsProblem {
                     f,
                     "{relative_shard_path}: Invalid directory name \"{shard_name}\", must be at most 2 ASCII characters consisting of a-z, 0-9, \"-\" or \"_\".",
                 ),
-            NixpkgsProblem::PackageNonDir { relative_package_dir } =>
+            NixpkgsProblem::PackageNonDir { package_name } => {
+                let relative_package_dir = structure::relative_dir_for_package(package_name);
                 write!(
                     f,
                     "{relative_package_dir}: This path is a file, but it should be a directory.",
-                ),
+                )
+            }
             NixpkgsProblem::CaseSensitiveDuplicate { relative_shard_path, first, second } =>
                 write!(
                     f,

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -136,10 +136,10 @@ pub struct RatchetError {
 
 #[derive(Clone)]
 pub enum RatchetErrorKind {
+    MovedOutOfByName,
     MovedOutOfByNameEmptyArg,
-    MovedOutOfByNameNonEmptyArg,
+    NewPackageNotUsingByName,
     NewPackageNotUsingByNameEmptyArg,
-    NewPackageNotUsingByNameNonEmptyArg,
 }
 
 impl fmt::Display for NixpkgsProblem {
@@ -149,7 +149,7 @@ impl fmt::Display for NixpkgsProblem {
                 shard_name,
                 kind,
             }) => {
-                let relative_shard_path = structure::relative_dir_for_shard(&shard_name);
+                let relative_shard_path = structure::relative_dir_for_shard(shard_name);
                 match kind {
                     ShardErrorKind::ShardNonDir =>
                         write!(
@@ -349,7 +349,7 @@ impl fmt::Display for NixpkgsProblem {
                               Please move the package back and remove the manual `callPackage`.
                             ",
                         ),
-                    RatchetErrorKind::MovedOutOfByNameNonEmptyArg =>
+                    RatchetErrorKind::MovedOutOfByName =>
                         // This can happen if users mistakenly assume that for custom arguments,
                         // pkgs/by-name can't be used.
                         writedoc!(
@@ -369,7 +369,7 @@ impl fmt::Display for NixpkgsProblem {
                               Since the second `callPackage` argument is `{{ }}`, no manual `callPackage` in {file} is needed anymore.
                             ",
                         ),
-                    RatchetErrorKind::NewPackageNotUsingByNameNonEmptyArg =>
+                    RatchetErrorKind::NewPackageNotUsingByName =>
                         writedoc!(
                             f,
                             "

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -331,16 +331,15 @@ impl fmt::Display for NixpkgsProblem {
                 let relative_package_file = structure::relative_file_for_package(package_name);
 
                 match kind {
-                    RatchetErrorKind::MovedOutOfByNameEmptyArg => {
+                    RatchetErrorKind::MovedOutOfByNameEmptyArg =>
                         writedoc!(
                             f,
                             "
                             - Attribute `pkgs.{package_name}` was previously defined in {relative_package_file}, but is now manually defined as `callPackage {call_package_arg} {{ /* ... */ }}` in {file}.
                               Please move the package back and remove the manual `callPackage`.
                             ",
-                        )
-                    },
-                    RatchetErrorKind::MovedOutOfByNameNonEmptyArg => {
+                        ),
+                    RatchetErrorKind::MovedOutOfByNameNonEmptyArg =>
                         // This can happen if users mistakenly assume that for custom arguments,
                         // pkgs/by-name can't be used.
                         writedoc!(
@@ -349,9 +348,8 @@ impl fmt::Display for NixpkgsProblem {
                             - Attribute `pkgs.{package_name}` was previously defined in {relative_package_file}, but is now manually defined as `callPackage {call_package_arg} {{ ... }}` in {file}.
                               While the manual `callPackage` is still needed, it's not necessary to move the package files.
                             ",
-                        )
-                    },
-                    RatchetErrorKind::NewPackageNotUsingByNameEmptyArg => {
+                        ),
+                    RatchetErrorKind::NewPackageNotUsingByNameEmptyArg =>
                         writedoc!(
                             f,
                             "
@@ -360,9 +358,8 @@ impl fmt::Display for NixpkgsProblem {
                               See `pkgs/by-name/README.md` for more details.
                               Since the second `callPackage` argument is `{{ }}`, no manual `callPackage` in {file} is needed anymore.
                             ",
-                        )
-                    },
-                    RatchetErrorKind::NewPackageNotUsingByNameNonEmptyArg => {
+                        ),
+                    RatchetErrorKind::NewPackageNotUsingByNameNonEmptyArg =>
                         writedoc!(
                             f,
                             "
@@ -371,8 +368,7 @@ impl fmt::Display for NixpkgsProblem {
                               See `pkgs/by-name/README.md` for more details.
                               Since the second `callPackage` argument is not `{{ }}`, the manual `callPackage` in {file} is still needed.
                             ",
-                        )
-                    },
+                        ),
                 }
             },
             NixpkgsProblem::InternalCallPackageUsed { attr_name } =>

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -17,7 +17,7 @@ pub enum NixpkgsProblem {
     ByNameOverride(ByNameOverrideError),
     Path(PathError),
     NixFile(NixFileError),
-    Ratchet(RatchetError),
+    TopLevelPackage(TopLevelPackageError),
 }
 
 #[derive(Clone)]
@@ -120,8 +120,9 @@ pub enum NixFileErrorKind {
     UnresolvablePathReference { io_error: String },
 }
 
+/// An error related to the introduction/move of a top-level package not using `pkgs/by-name`, but it should
 #[derive(Clone)]
-pub struct RatchetError {
+pub struct TopLevelPackageError {
     pub package_name: String,
     pub call_package_path: Option<RelativePathBuf>,
     pub file: RelativePathBuf,
@@ -353,7 +354,7 @@ impl fmt::Display for NixpkgsProblem {
                         ),
                 }
             },
-            NixpkgsProblem::Ratchet(RatchetError {
+            NixpkgsProblem::TopLevelPackage(TopLevelPackageError {
                 package_name,
                 call_package_path,
                 file,

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -41,7 +41,6 @@ pub enum NixpkgsProblem {
         relative_package_dir: RelativePathBuf,
     },
     UndefinedAttr {
-        relative_package_file: RelativePathBuf,
         package_name: String,
     },
     EmptyArgument {
@@ -80,7 +79,6 @@ pub enum NixpkgsProblem {
         definition: String,
     },
     NonDerivation {
-        relative_package_file: RelativePathBuf,
         package_name: String,
     },
     OutsideSymlink {
@@ -188,11 +186,13 @@ impl fmt::Display for NixpkgsProblem {
                     f,
                     "{relative_package_dir}: \"{PACKAGE_NIX_FILENAME}\" must be a file.",
                 ),
-            NixpkgsProblem::UndefinedAttr { relative_package_file, package_name } =>
+            NixpkgsProblem::UndefinedAttr {  package_name } => {
+                let relative_package_file = structure::relative_file_for_package(package_name);
                 write!(
                     f,
                     "pkgs.{package_name}: This attribute is not defined but it should be defined automatically as {relative_package_file}",
-                ),
+                )
+            }
             NixpkgsProblem::EmptyArgument { package_name, file, line, column, definition } => {
                 let relative_package_dir = structure::relative_dir_for_package(package_name);
                 let relative_package_file = structure::relative_file_for_package(package_name);
@@ -280,11 +280,13 @@ impl fmt::Display for NixpkgsProblem {
                     ",
                 )
             }
-            NixpkgsProblem::NonDerivation { relative_package_file, package_name } =>
+            NixpkgsProblem::NonDerivation { package_name } => {
+                let relative_package_file = structure::relative_file_for_package(package_name);
                 write!(
                     f,
                     "pkgs.{package_name}: This attribute defined by {relative_package_file} is not a derivation",
-                ),
+                )
+            }
             NixpkgsProblem::OutsideSymlink { relative_package_dir, subpath } =>
                 write!(
                     f,

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -28,7 +28,7 @@ pub enum NixpkgsProblem {
     },
     InvalidPackageName {
         relative_package_dir: RelativePathBuf,
-        package_name: String,
+        invalid_package_name: String,
     },
     IncorrectShard {
         relative_package_dir: RelativePathBuf,
@@ -166,10 +166,10 @@ impl fmt::Display for NixpkgsProblem {
                     f,
                     "{relative_shard_path}: Duplicate case-sensitive package directories {first:?} and {second:?}.",
                 ),
-            NixpkgsProblem::InvalidPackageName { relative_package_dir, package_name } =>
+            NixpkgsProblem::InvalidPackageName { relative_package_dir, invalid_package_name } =>
                 write!(
                     f,
-                    "{relative_package_dir}: Invalid package directory name \"{package_name}\", must be ASCII characters consisting of a-z, A-Z, 0-9, \"-\" or \"_\".",
+                    "{relative_package_dir}: Invalid package directory name \"{invalid_package_name}\", must be ASCII characters consisting of a-z, A-Z, 0-9, \"-\" or \"_\".",
                 ),
             NixpkgsProblem::IncorrectShard { relative_package_dir, correct_relative_package_dir } =>
                 write!(

--- a/src/nixpkgs_problem.rs
+++ b/src/nixpkgs_problem.rs
@@ -20,6 +20,7 @@ pub enum NixpkgsProblem {
     TopLevelPackage(TopLevelPackageError),
 }
 
+/// A file structure error involving a shard (e.g. `fo` is the shard in the path `pkgs/by-name/fo/foo/package.nix`)
 #[derive(Clone)]
 pub struct ShardError {
     pub shard_name: String,
@@ -33,6 +34,7 @@ pub enum ShardErrorKind {
     CaseSensitiveDuplicate { first: OsString, second: OsString },
 }
 
+/// A file structure error involving the package name and/or path.
 #[derive(Clone)]
 pub struct PackageError {
     pub relative_package_dir: RelativePathBuf,
@@ -54,6 +56,8 @@ pub enum PackageErrorKind {
     PackageNixDir,
 }
 
+/// An error related to checks involving by-name attributes. For example, attribute `foo` in
+/// `pkgs/by-name/fo/foo/package.nix`.
 #[derive(Clone)]
 pub struct ByNameError {
     pub attribute_name: String,
@@ -68,6 +72,8 @@ pub enum ByNameErrorKind {
     CannotDetermineAttributeLocation,
 }
 
+/// An error related to packages in `pkgs/by-name` that are manually overridden, e.g. in
+/// all-packages.nix
 #[derive(Clone)]
 pub struct ByNameOverrideError {
     pub package_name: String,
@@ -90,6 +96,8 @@ pub enum ByNameOverrideErrorKind {
     NonPath,
 }
 
+/// An error that results from checks that verify a specific path does not reference outside the
+/// package directory.
 #[derive(Clone)]
 pub struct PathError {
     pub relative_package_dir: RelativePathBuf,
@@ -103,6 +111,8 @@ pub enum PathErrorKind {
     UnresolvableSymlink { io_error: String },
 }
 
+/// An error that results from checks that verify a nix file that contains a path expression does
+/// not reference outside the package.
 #[derive(Clone)]
 pub struct NixFileError {
     pub relative_package_dir: RelativePathBuf,
@@ -120,7 +130,8 @@ pub enum NixFileErrorKind {
     UnresolvablePathReference { io_error: String },
 }
 
-/// An error related to the introduction/move of a top-level package not using `pkgs/by-name`, but it should
+/// An error related to the introduction/move of a top-level package not using `pkgs/by-name`, but
+/// it should.
 #[derive(Clone)]
 pub struct TopLevelPackageError {
     pub package_name: String,

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -3,7 +3,7 @@
 //! Each type has a `compare` method that validates the ratchet checks for that item.
 
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::nixpkgs_problem::{NixpkgsProblem, RatchetError, RatchetErrorKind};
+use crate::nixpkgs_problem::{NixpkgsProblem, RatchetError};
 use crate::validation::{self, Validation, Validation::Success};
 use relative_path::RelativePathBuf;
 use std::collections::HashMap;
@@ -157,12 +157,8 @@ impl ToNixpkgsProblem for UsesByName {
             package_name: name.to_owned(),
             call_package_path: to.relative_path.clone(),
             file: file.to_owned(),
-            kind: match (optional_from, to.empty_arg) {
-                (Some(()), true) => RatchetErrorKind::MovedOutOfByNameEmptyArg,
-                (Some(()), false) => RatchetErrorKind::MovedOutOfByName,
-                (None, true) => RatchetErrorKind::NewPackageNotUsingByNameEmptyArg,
-                (None, false) => RatchetErrorKind::NewPackageNotUsingByName,
-            },
+            is_new: optional_from.is_none(),
+            is_empty: to.empty_arg,
         })
     }
 }

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -3,7 +3,7 @@
 //! Each type has a `compare` method that validates the ratchet checks for that item.
 
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::nixpkgs_problem::{NixpkgsProblem, RatchetError};
+use crate::nixpkgs_problem::{NixpkgsProblem, TopLevelPackageError};
 use crate::validation::{self, Validation, Validation::Success};
 use relative_path::RelativePathBuf;
 use std::collections::HashMap;
@@ -153,7 +153,7 @@ impl ToNixpkgsProblem for UsesByName {
         optional_from: Option<()>,
         (to, file): &Self::ToContext,
     ) -> NixpkgsProblem {
-        NixpkgsProblem::Ratchet(RatchetError {
+        NixpkgsProblem::TopLevelPackage(TopLevelPackageError {
             package_name: name.to_owned(),
             call_package_path: to.relative_path.clone(),
             file: file.to_owned(),

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -159,9 +159,9 @@ impl ToNixpkgsProblem for UsesByName {
             file: file.to_owned(),
             kind: match (optional_from, to.empty_arg) {
                 (Some(()), true) => RatchetErrorKind::MovedOutOfByNameEmptyArg,
-                (Some(()), false) => RatchetErrorKind::MovedOutOfByNameNonEmptyArg,
+                (Some(()), false) => RatchetErrorKind::MovedOutOfByName,
                 (None, true) => RatchetErrorKind::NewPackageNotUsingByNameEmptyArg,
-                (None, false) => RatchetErrorKind::NewPackageNotUsingByNameNonEmptyArg,
+                (None, false) => RatchetErrorKind::NewPackageNotUsingByName,
             },
         })
     }

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -153,7 +153,7 @@ impl ToNixpkgsProblem for UsesByName {
         optional_from: Option<()>,
         (to, file): &Self::ToContext,
     ) -> NixpkgsProblem {
-        NixpkgsProblem::RatchetProblem(RatchetError {
+        NixpkgsProblem::Ratchet(RatchetError {
             package_name: name.to_owned(),
             call_package_path: to.relative_path.clone(),
             file: file.to_owned(),

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -3,7 +3,7 @@
 //! Each type has a `compare` method that validates the ratchet checks for that item.
 
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::nixpkgs_problem::NixpkgsProblem;
+use crate::nixpkgs_problem::{NixpkgsProblem, RatchetError, RatchetErrorKind};
 use crate::validation::{self, Validation, Validation::Success};
 use relative_path::RelativePathBuf;
 use std::collections::HashMap;
@@ -153,32 +153,16 @@ impl ToNixpkgsProblem for UsesByName {
         optional_from: Option<()>,
         (to, file): &Self::ToContext,
     ) -> NixpkgsProblem {
-        if let Some(()) = optional_from {
-            if to.empty_arg {
-                NixpkgsProblem::MovedOutOfByNameEmptyArg {
-                    package_name: name.to_owned(),
-                    call_package_path: to.relative_path.clone(),
-                    file: file.to_owned(),
-                }
-            } else {
-                NixpkgsProblem::MovedOutOfByNameNonEmptyArg {
-                    package_name: name.to_owned(),
-                    call_package_path: to.relative_path.clone(),
-                    file: file.to_owned(),
-                }
-            }
-        } else if to.empty_arg {
-            NixpkgsProblem::NewPackageNotUsingByNameEmptyArg {
-                package_name: name.to_owned(),
-                call_package_path: to.relative_path.clone(),
-                file: file.to_owned(),
-            }
-        } else {
-            NixpkgsProblem::NewPackageNotUsingByNameNonEmptyArg {
-                package_name: name.to_owned(),
-                call_package_path: to.relative_path.clone(),
-                file: file.to_owned(),
-            }
-        }
+        NixpkgsProblem::RatchetProblem(RatchetError {
+            package_name: name.to_owned(),
+            call_package_path: to.relative_path.clone(),
+            file: file.to_owned(),
+            kind: match (optional_from, to.empty_arg) {
+                (Some(()), true) => RatchetErrorKind::MovedOutOfByNameEmptyArg,
+                (Some(()), false) => RatchetErrorKind::MovedOutOfByNameNonEmptyArg,
+                (None, true) => RatchetErrorKind::NewPackageNotUsingByNameEmptyArg,
+                (None, false) => RatchetErrorKind::NewPackageNotUsingByNameNonEmptyArg,
+            },
+        })
     }
 }

--- a/src/references.rs
+++ b/src/references.rs
@@ -50,7 +50,7 @@ fn check_path(
 ) -> validation::Result<()> {
     let path = subpath.to_path(absolute_package_dir);
     let to_problem = |kind| {
-        NixpkgsProblem::PathProblem(PathError {
+        NixpkgsProblem::Path(PathError {
             relative_package_dir: relative_package_dir.to_owned(),
             subpath: subpath.to_owned(),
             kind,
@@ -134,7 +134,7 @@ fn check_nix_file(
             };
 
             let to_problem = |kind| {
-                NixpkgsProblem::NixFileProblem(NixFileError {
+                NixpkgsProblem::NixFile(NixFileError {
                     relative_package_dir: relative_package_dir.to_owned(),
                     subpath: subpath.to_owned(),
                     line: nix_file.line_index.line(node.text_range().start().into()),

--- a/src/references.rs
+++ b/src/references.rs
@@ -128,8 +128,11 @@ fn check_nix_file(
 
     Ok(validation::sequence_(
         nix_file.syntax_root.syntax().descendants().map(|node| {
+            let line = nix_file.line_index.line(node.text_range().start().into());
+            let text = node.text().to_string();
+
             // We're only interested in Path expressions
-            let Some(path) = rnix::ast::Path::cast(node.clone()) else {
+            let Some(path) = rnix::ast::Path::cast(node) else {
                 return Success(());
             };
 
@@ -137,8 +140,8 @@ fn check_nix_file(
                 NixpkgsProblem::NixFile(NixFileError {
                     relative_package_dir: relative_package_dir.to_owned(),
                     subpath: subpath.to_owned(),
-                    line: nix_file.line_index.line(node.text_range().start().into()),
-                    text: node.text().to_string(),
+                    line,
+                    text,
                     kind,
                 })
             };

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -134,7 +134,7 @@ fn check_package(
         let result = if !package_name_valid {
             NixpkgsProblem::InvalidPackageName {
                 relative_package_dir: relative_package_dir.clone(),
-                package_name: package_name.clone(),
+                invalid_package_name: package_name.clone(),
             }
             .into()
         } else {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -126,7 +126,7 @@ fn check_package(
 
     Ok(if !package_path.is_dir() {
         NixpkgsProblem::PackageNonDir {
-            relative_package_dir: relative_package_dir.clone(),
+            package_name: package_name.clone(),
         }
         .into()
     } else {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1,8 +1,6 @@
-use crate::nixpkgs_problem::NixpkgsProblem;
-use crate::nixpkgs_problem::PackageError;
-use crate::nixpkgs_problem::PackageErrorKind;
-use crate::nixpkgs_problem::ShardError;
-use crate::nixpkgs_problem::ShardErrorKind;
+use crate::nixpkgs_problem::{
+    NixpkgsProblem, PackageError, PackageErrorKind, ShardError, ShardErrorKind,
+};
 use crate::references;
 use crate::utils;
 use crate::utils::{BASE_SUBPATH, PACKAGE_NIX_FILENAME};


### PR DESCRIPTION
Work related to: https://github.com/NixOS/nixpkgs-check-by-name/issues/2

This pull request does not change the single-line vs multi-line style or any of the error messages. The goal here is to reduce code duplication.

A lot of the NixpkgsProblem enum variants had common fields more or less due to the context of where the error originated.

I grouped these similar problems into structs which contains the common fields and a `kind` enum to differentiate between the different types of problems.
