### PR TITLE
Include clippy lints for tests

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage {
   preCheck = initNix;
   postCheck = ''
     cargo fmt --check
-    cargo clippy -- -D warnings
+    # --tests or --all-targets include tests for linting
+    cargo clippy --all-targets -- -D warnings
   '';
   postInstall = ''
     wrapProgram $out/bin/nixpkgs-check-by-name \

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ mod tests {
         let temp_nixpkgs = tempdir()?;
         let path = temp_nixpkgs.path();
 
-        if is_case_insensitive_fs(&path)? {
+        if is_case_insensitive_fs(path)? {
             eprintln!("We're on a case-insensitive filesystem, skipping case-sensitivity test");
             return Ok(());
         }
@@ -223,7 +223,7 @@ mod tests {
 
         test_nixpkgs(
             "case_sensitive",
-            &path,
+            path,
             "pkgs/by-name/fo: Duplicate case-sensitive package directories \"foO\" and \"foo\".\nThis PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.\n",
         )?;
 


### PR DESCRIPTION
Randomly noticed some warnings in `main.rs` since [I improved my rust-analyzer integration in Emacs](https://github.com/willbush/system/blob/6fb4c108ab0a471430aac2ff5c5d925bb31292b7/configs/emacs/default/modules/init-prog-tools.el#L394). Looked into why and apparently `cargo clippy` doesn't include tests by default:

https://github.com/rust-lang/rust-clippy/issues/1436#issuecomment-462059561
https://github.com/rust-lang/rust-clippy/issues/10690

We could pass `--all-targets` or `--tests` to fix the issue. I liked the former because its more obvious that lints are checked for more than *just* tests.
