### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,15 +453,15 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre604449.807c549feabc/nixexprs.tar.xz",
-      "hash": "18684ycy5a5z04gzscfz9xvvxk1arxfl69iqpfl2qz3hlyyplw97"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre609215.b0dab7cc34ef/nixexprs.tar.xz",
+      "hash": "1ackk3rpq4v151i0np4yhai00km9z8bjdh242n9ld1bd1ha2kmza"
     }
   },
   "version": 3


### PR DESCRIPTION
Run automated updates
<details><summary>cargo changes</summary>

```
    Updating crates.io index
    Updating strsim v0.11.0 -> v0.11.1
    Updating syn v2.0.57 -> v2.0.58
```
</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre604449.807c549feabc/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre609215.b0dab7cc34ef/nixexprs.tar.xz
-    hash: 18684ycy5a5z04gzscfz9xvvxk1arxfl69iqpfl2qz3hlyyplw97
+    hash: 1ackk3rpq4v151i0np4yhai00km9z8bjdh242n9ld1bd1ha2kmza
[INFO ] Update successful.
```
</details>
