### PR TITLE
Add dependabot configuration to update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
@infinisil I recall you saying something about feeling dependabot is too Github specific. However, I'm not aware of an easier way to keep Github actions up-to-date. Speaking of not being GH specific, worth considering auto-mirroring this repo to another place just for backup? I thought about doing the same for my personal repos, but never got around to it.