### PR TITLE
Explicitly expose version to avoid release script failure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,13 +31,15 @@ let
     nix-store --init
   '';
 
+  # Determine version from Cargo.toml
+  version = (lib.importTOML ./Cargo.toml).package.version;
 
   results = {
     # We're using this value as the root result. By default, derivations expose all of their
     # internal attributes, which is very messy. We prevent this using lib.lazyDerivation
     build = lib.lazyDerivation {
       derivation = pkgs.callPackage ./package.nix {
-        inherit nixpkgsLibPath initNix runtimeExprPath testNixpkgsPath;
+        inherit nixpkgsLibPath initNix runtimeExprPath testNixpkgsPath version;
       };
     };
 
@@ -132,4 +134,6 @@ results.build // results // {
   # Built by CI
   ci = pkgs.linkFarm "ci" results;
 
+  # Used by CI to determine whether a new version should be released
+  inherit version;
 }

--- a/package.nix
+++ b/package.nix
@@ -10,10 +10,10 @@
   initNix,
   runtimeExprPath,
   testNixpkgsPath,
+  version,
 }:
 let
   fs = lib.fileset;
-  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 in
 rustPlatform.buildRustPackage {
   pname = "nixpkgs-check-by-name";

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ root=$(git rev-parse --show-toplevel)
 repository=${GITHUB_REPOSITORY:-NixOS/nixpkgs-check-by-name}
 
 # Get the version from the Cargo.toml file
-version=$(nixeval "$root" -A build.version)
+version=$(nixeval "$root" -A version)
 echo "Current version is $version"
 
 if existingRelease=$(gh api \


### PR DESCRIPTION
lazyDerivation limits which attributes are exposed, and version is not currently one of them, so we need to explicitly expose it.

This fixes this CD failure:

https://github.com/NixOS/nixpkgs-check-by-name/actions/runs/8637321506/job/23679230914

This was accidentally introduced in #40 (should've made a separate PR for the first commit after all!)