### PR TITLE
Format Rust, Nix and Bash via treefmt

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Reformatted all Nix files
+81d712a6c4e020bf545fb931b3106aff64871962
+
+# Reformatted all Bash scripts
+b1306dd5ae96b0fb934256d91708733c1f850016

--- a/default.nix
+++ b/default.nix
@@ -41,6 +41,8 @@ let
 
     programs.rustfmt.enable = true;
     programs.nixfmt-rfc-style.enable = true;
+    programs.shfmt.enable = true;
+    settings.formatter.shfmt.options = [ "--space-redirects" ];
   };
 
   results = {

--- a/default.nix
+++ b/default.nix
@@ -9,8 +9,8 @@ in
 let
   pkgs = import nixpkgs {
     inherit system;
-    config = {};
-    overlays = [];
+    config = { };
+    overlays = [ ];
   };
   inherit (pkgs) lib;
 
@@ -40,6 +40,7 @@ let
     projectRootFile = ".git/config";
 
     programs.rustfmt.enable = true;
+    programs.nixfmt-rfc-style.enable = true;
   };
 
   results = {
@@ -47,7 +48,13 @@ let
     # internal attributes, which is very messy. We prevent this using lib.lazyDerivation
     build = lib.lazyDerivation {
       derivation = pkgs.callPackage ./package.nix {
-        inherit nixpkgsLibPath initNix runtimeExprPath testNixpkgsPath version;
+        inherit
+          nixpkgsLibPath
+          initNix
+          runtimeExprPath
+          testNixpkgsPath
+          version
+          ;
       };
     };
 
@@ -77,9 +84,7 @@ let
         updateScripts = {
           npins = pkgs.writeShellApplication {
             name = "update-npins";
-            runtimeInputs = with pkgs; [
-              npins
-            ];
+            runtimeInputs = with pkgs; [ npins ];
             text = ''
               echo "<details><summary>npins changes</summary>"
               # Needed because GitHub's rendering of the first body line breaks down otherwise
@@ -92,9 +97,7 @@ let
           };
           cargo = pkgs.writeShellApplication {
             name = "update-cargo";
-            runtimeInputs = with pkgs; [
-              cargo
-            ];
+            runtimeInputs = with pkgs; [ cargo ];
             text = ''
               echo "<details><summary>cargo changes</summary>"
               # Needed because GitHub's rendering of the first body line breaks down otherwise
@@ -130,21 +133,25 @@ let
       };
 
     # Tests the tool on the pinned Nixpkgs tree, this is a good sanity check
-    nixpkgsCheck = pkgs.runCommand "test-nixpkgs-check-by-name" {
-      nativeBuildInputs = [
-        results.build
-        pkgs.nix
-      ];
-      nixpkgsPath = nixpkgs;
-    } ''
-      ${initNix}
-      nixpkgs-check-by-name --base "$nixpkgsPath" "$nixpkgsPath"
-      touch $out
-    '';
+    nixpkgsCheck =
+      pkgs.runCommand "test-nixpkgs-check-by-name"
+        {
+          nativeBuildInputs = [
+            results.build
+            pkgs.nix
+          ];
+          nixpkgsPath = nixpkgs;
+        }
+        ''
+          ${initNix}
+          nixpkgs-check-by-name --base "$nixpkgsPath" "$nixpkgsPath"
+          touch $out
+        '';
   };
-
 in
-results.build // results // {
+results.build
+// results
+// {
 
   # Good for debugging
   inherit pkgs;

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -3,18 +3,32 @@ let
   data = builtins.fromJSON (builtins.readFile ./sources.json);
   version = data.version;
 
-  mkSource = spec:
-    assert spec ? type; let
+  mkSource =
+    spec:
+    assert spec ? type;
+    let
       path =
-        if spec.type == "Git" then mkGitSource spec
-        else if spec.type == "GitRelease" then mkGitSource spec
-        else if spec.type == "PyPi" then mkPyPiSource spec
-        else if spec.type == "Channel" then mkChannelSource spec
-        else builtins.throw "Unknown source type ${spec.type}";
+        if spec.type == "Git" then
+          mkGitSource spec
+        else if spec.type == "GitRelease" then
+          mkGitSource spec
+        else if spec.type == "PyPi" then
+          mkPyPiSource spec
+        else if spec.type == "Channel" then
+          mkChannelSource spec
+        else
+          builtins.throw "Unknown source type ${spec.type}";
     in
     spec // { outPath = path; };
 
-  mkGitSource = { repository, revision, url ? null, hash, ... }:
+  mkGitSource =
+    {
+      repository,
+      revision,
+      url ? null,
+      hash,
+      ...
+    }:
     assert repository ? type;
     # At the moment, either it is a plain git repository (which has an url), or it is a GitHub/GitLab repository
     # In the latter case, there we will always be an url to the tarball
@@ -23,19 +37,23 @@ let
         inherit url;
         sha256 = hash; # FIXME: check nix version & use SRI hashes
       })
-    else assert repository.type == "Git"; builtins.fetchGit {
-      url = repository.url;
-      rev = revision;
-      # hash = hash;
-    };
+    else
+      assert repository.type == "Git";
+      builtins.fetchGit {
+        url = repository.url;
+        rev = revision;
+        # hash = hash;
+      };
 
-  mkPyPiSource = { url, hash, ... }:
+  mkPyPiSource =
+    { url, hash, ... }:
     builtins.fetchurl {
       inherit url;
       sha256 = hash;
     };
 
-  mkChannelSource = { url, hash, ... }:
+  mkChannelSource =
+    { url, hash, ... }:
     builtins.fetchTarball {
       inherit url;
       sha256 = hash;

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -5,6 +5,18 @@
       "name": "nixpkgs-unstable",
       "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre612007.2748d22b45a9/nixexprs.tar.xz",
       "hash": "0l6yzjxvlilidsixqz54110n84yzcjsm74wvrs69pvs73gk1w1xa"
+    },
+    "treefmt-nix": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "numtide",
+        "repo": "treefmt-nix"
+      },
+      "branch": "main",
+      "revision": "49dc4a92b02b8e68798abd99184f228243b6e3ac",
+      "url": "https://github.com/numtide/treefmt-nix/archive/49dc4a92b02b8e68798abd99184f228243b6e3ac.tar.gz",
+      "hash": "0qlhb0xvcc3al19irclxk7vnppd9m6b5vi3nbjb9dylphs306x1p"
     }
   },
   "version": 3

--- a/package.nix
+++ b/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   nix,
-  rustfmt,
   clippy,
   makeWrapper,
 
@@ -30,7 +29,6 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ./Cargo.lock;
   nativeBuildInputs = [
     nix
-    rustfmt
     clippy
     makeWrapper
   ];
@@ -38,7 +36,6 @@ rustPlatform.buildRustPackage {
   env.NIX_PATH = "test-nixpkgs=${testNixpkgsPath}:test-nixpkgs/lib=${nixpkgsLibPath}";
   preCheck = initNix;
   postCheck = ''
-    cargo fmt --check
     # --tests or --all-targets include tests for linting
     cargo clippy --all-targets -- -D warnings
   '';

--- a/package.nix
+++ b/package.nix
@@ -43,5 +43,4 @@ rustPlatform.buildRustPackage {
     wrapProgram $out/bin/nixpkgs-check-by-name \
       --set NIX_CHECK_BY_NAME_EXPR_PATH "$NIX_CHECK_BY_NAME_EXPR_PATH"
   '';
-
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,7 +32,7 @@ fi
 
 echo "Building release artifact for system $system"
 
-nix-build "$root" -A build -o "$tmp/build" >/dev/null
+nix-build "$root" -A build -o "$tmp/build" > /dev/null
 readarray -t closure < <(nix-store -qR "$tmp/build")
 nix-store --export "${closure[@]}" > "$tmp/$system.nar"
 gzip "$tmp/$system.nar"

--- a/scripts/update-github-actions.sh
+++ b/scripts/update-github-actions.sh
@@ -22,7 +22,7 @@ trap 'rm -rf "$tmp"' exit
 
 # Use dependency groups to update all dependencies together
 # Note that repo is not used because we pass `--local` on the CLI
-cat <<EOF > "$tmp/input.yml"
+cat << EOF > "$tmp/input.yml"
 job:
   package-manager: "github_actions"
   allowed-updates:
@@ -39,13 +39,13 @@ job:
 EOF
 
 if create_pull_request=$(LOCAL_GITHUB_ACCESS_TOKEN="$githubToken" \
-  dependabot update --file "$tmp/input.yml" --local "$REPO_ROOT" \
-  | jq --exit-status 'select(.type == "create_pull_request").data'); then
+  dependabot update --file "$tmp/input.yml" --local "$REPO_ROOT" |
+  jq --exit-status 'select(.type == "create_pull_request").data'); then
 
   jq --exit-status --raw-output '."pr-body"' <<< "$create_pull_request"
 
-  jq --compact-output '."updated-dependency-files"[]' <<< "$create_pull_request" \
-    | while read -r fileUpdate; do
+  jq --compact-output '."updated-dependency-files"[]' <<< "$create_pull_request" |
+    while read -r fileUpdate; do
       file=$(jq --exit-status --raw-output '.name' <<< "$fileUpdate")
       # --join-output makes sure to not output a trailing newline
       jq --exit-status --raw-output --join-output '.content' <<< "$fileUpdate" > "$REPO_ROOT/$file"

--- a/tests/aliases/aliases.nix
+++ b/tests/aliases/aliases.nix
@@ -1,3 +1,1 @@
-self: super: {
-  baz = self.foo;
-}
+self: super: { baz = self.foo; }

--- a/tests/aliases/pkgs/top-level/all-packages.nix
+++ b/tests/aliases/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  bar = self.foo;
-}
+self: super: { bar = self.foo; }

--- a/tests/alt-callPackage/pkgs/top-level/all-packages.nix
+++ b/tests/alt-callPackage/pkgs/top-level/all-packages.nix
@@ -1,7 +1,6 @@
 self: super: {
 
-  alt.callPackage = self.lib.callPackageWith {};
+  alt.callPackage = self.lib.callPackageWith { };
 
   foo = self.alt.callPackage ({ }: self.someDrv) { };
-
 }

--- a/tests/broken-autocall/default.nix
+++ b/tests/broken-autocall/default.nix
@@ -1,4 +1,1 @@
-args:
-builtins.removeAttrs
-  (import <test-nixpkgs> { root = ./.; } args)
-  [ "foo" ]
+args: builtins.removeAttrs (import <test-nixpkgs> { root = ./.; } args) [ "foo" ]

--- a/tests/by-name-failure/expected
+++ b/tests/by-name-failure/expected
@@ -6,12 +6,12 @@ error:
 
        … while evaluating attribute 'ByName'
 
-         at src/eval.nix:82:5:
+         at src/eval.nix:77:7:
 
-           81|     inherit name;
-           82|     value.ByName =
-             |     ^
-           83|       if ! pkgs ? ${name} then
+           76|       inherit name;
+           77|       value.ByName =
+             |       ^
+           78|         if !pkgs ? ${name} then
 
        (stack trace truncated; use '--show-trace' to show the full trace)
 

--- a/tests/by-name-failure/pkgs/by-name/fo/foo/package.nix
+++ b/tests/by-name-failure/pkgs/by-name/fo/foo/package.nix
@@ -1,4 +1,3 @@
 { }:
 # If we caused an actual Nix failure
-builtins.trace "This should be on stderr!"
-throw "This is an error!"
+builtins.trace "This should be on stderr!" throw "This is an error!"

--- a/tests/callPackage-syntax/pkgs/top-level/all-packages.nix
+++ b/tests/callPackage-syntax/pkgs/top-level/all-packages.nix
@@ -1,7 +1,10 @@
 self: super: {
-  set = self.callPackages ({ callPackage }: {
-    foo = callPackage ({ someDrv }: someDrv) { };
-  }) { };
+  set = self.callPackages (
+    { callPackage }:
+    {
+      foo = callPackage ({ someDrv }: someDrv) { };
+    }
+  ) { };
 
   inherit (self.set) foo;
 }

--- a/tests/move-to-non-by-name/pkgs/top-level/all-packages.nix
+++ b/tests/move-to-non-by-name/pkgs/top-level/all-packages.nix
@@ -1,10 +1,6 @@
 self: super: {
   foo1 = self.callPackage ({ someDrv }: someDrv) { };
   foo2 = self.callPackage ./../../without-config.nix { };
-  foo3 = self.callPackage ({ someDrv, enableFoo }: someDrv) {
-    enableFoo = null;
-  };
-  foo4 = self.callPackage ./../../with-config.nix {
-    enableFoo = null;
-  };
+  foo3 = self.callPackage ({ someDrv, enableFoo }: someDrv) { enableFoo = null; };
+  foo4 = self.callPackage ./../../with-config.nix { enableFoo = null; };
 }

--- a/tests/multiple-failures/expected
+++ b/tests/multiple-failures/expected
@@ -6,9 +6,9 @@ pkgs/by-name/aa: This is a file, but it should be a directory.
 pkgs/by-name/ba/bar: This path is a file, but it should be a directory.
 pkgs/by-name/ba/baz: "package.nix" must be a file.
 pkgs/by-name/ba/foo: Incorrect directory location, should be pkgs/by-name/fo/foo instead.
-pkgs/by-name/ba/foo: File package.nix at line 2 contains the path expression "/bar" which cannot be resolved: No such file or directory (os error 2).
-pkgs/by-name/ba/foo: File package.nix at line 3 contains the path expression "../." which may point outside the directory of that package.
-pkgs/by-name/ba/foo: File package.nix at line 4 contains the nix search path expression "<nixpkgs>" which may point outside the directory of that package.
-pkgs/by-name/ba/foo: File package.nix at line 5 contains the path expression "./${"test"}", which is not yet supported and may point outside the directory of that package.
+pkgs/by-name/ba/foo: File package.nix at line 4 contains the path expression "/bar" which cannot be resolved: No such file or directory (os error 2).
+pkgs/by-name/ba/foo: File package.nix at line 5 contains the path expression "../." which may point outside the directory of that package.
+pkgs/by-name/ba/foo: File package.nix at line 6 contains the nix search path expression "<nixpkgs>" which may point outside the directory of that package.
+pkgs/by-name/ba/foo: File package.nix at line 7 contains the path expression "./${"test"}", which is not yet supported and may point outside the directory of that package.
 pkgs/by-name/fo/foo: Missing required "package.nix" file.
 This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/multiple-failures/pkgs/by-name/ba/foo/package.nix
+++ b/tests/multiple-failures/pkgs/by-name/ba/foo/package.nix
@@ -1,4 +1,6 @@
-{ someDrv }: someDrv // {
+{ someDrv }:
+someDrv
+// {
   escapeAbsolute = /bar;
   escapeRelative = ../.;
   nixPath = <nixpkgs>;

--- a/tests/new-package-non-by-name/base/pkgs/top-level/all-packages.nix
+++ b/tests/new-package-non-by-name/base/pkgs/top-level/all-packages.nix
@@ -1,5 +1,4 @@
 self: super: {
 
   before = self.callPackage ({ someDrv }: someDrv) { };
-
 }

--- a/tests/new-package-non-by-name/pkgs/top-level/all-packages.nix
+++ b/tests/new-package-non-by-name/pkgs/top-level/all-packages.nix
@@ -2,10 +2,6 @@ self: super: {
   before = self.callPackage ({ someDrv }: someDrv) { };
   new1 = self.callPackage ({ someDrv }: someDrv) { };
   new2 = self.callPackage ./../../without-config.nix { };
-  new3 = self.callPackage ({ someDrv, enableNew }: someDrv) {
-    enableNew = null;
-  };
-  new4 = self.callPackage ./../../with-config.nix {
-    enableNew = null;
-  };
+  new3 = self.callPackage ({ someDrv, enableNew }: someDrv) { enableNew = null; };
+  new4 = self.callPackage ./../../with-config.nix { enableNew = null; };
 }

--- a/tests/no-eval/base/pkgs/top-level/all-packages.nix
+++ b/tests/no-eval/base/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  futureEval = throw "foo";
-}
+self: super: { futureEval = throw "foo"; }

--- a/tests/non-by-name-trace/pkgs/top-level/all-packages.nix
+++ b/tests/non-by-name-trace/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  foo = self.lib.warn "foo should not be used anymore" null;
-}
+self: super: { foo = self.lib.warn "foo should not be used anymore" null; }

--- a/tests/non-syntactical-callPackage-by-name/pkgs/top-level/all-packages.nix
+++ b/tests/non-syntactical-callPackage-by-name/pkgs/top-level/all-packages.nix
@@ -2,5 +2,4 @@ self: super: {
 
   bar = (x: x) self.callPackage ./../by-name/fo/foo/package.nix { someFlag = true; };
   foo = self.bar;
-
 }

--- a/tests/only-callPackage-derivations/pkgs/top-level/all-packages.nix
+++ b/tests/only-callPackage-derivations/pkgs/top-level/all-packages.nix
@@ -1,5 +1,6 @@
 self: super: {
-  alternateCallPackage = self.myScope.callPackage ({ myScopeValue, someDrv }:
+  alternateCallPackage = self.myScope.callPackage (
+    { myScopeValue, someDrv }:
     assert myScopeValue;
     someDrv
   ) { };
@@ -8,9 +9,12 @@ self: super: {
     myScopeValue = true;
   });
 
-  myPackages = self.callPackages ({ someDrv }: {
-    a = someDrv;
-    b = someDrv;
-  }) { };
+  myPackages = self.callPackages (
+    { someDrv }:
+    {
+      a = someDrv;
+      b = someDrv;
+    }
+  ) { };
   inherit (self.myPackages) a b;
 }

--- a/tests/override-different-file/expected
+++ b/tests/override-different-file/expected
@@ -2,7 +2,7 @@
 
     nonDerivation = callPackage ./../by-name/no/nonDerivation/package.nix { /* ... */ };
 
-  However, in this PR, the first `callPackage` argument is the wrong path. See the definition in pkgs/top-level/all-packages.nix:2:
+  However, in this PR, the first `callPackage` argument is the wrong path. See the definition in pkgs/top-level/all-packages.nix:1:
 
     nonDerivation = callPackage ./../../someDrv.nix { /* ... */ };
 

--- a/tests/override-different-file/pkgs/top-level/all-packages.nix
+++ b/tests/override-different-file/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  nonDerivation = self.callPackage ./../../someDrv.nix { };
-}
+self: super: { nonDerivation = self.callPackage ./../../someDrv.nix { }; }

--- a/tests/override-empty-arg-gradual/base/pkgs/top-level/all-packages.nix
+++ b/tests/override-empty-arg-gradual/base/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { };
-}
+self: super: { nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { }; }

--- a/tests/override-empty-arg-gradual/pkgs/top-level/all-packages.nix
+++ b/tests/override-empty-arg-gradual/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { };
-}
+self: super: { nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { }; }

--- a/tests/override-empty-arg/expected
+++ b/tests/override-empty-arg/expected
@@ -2,7 +2,7 @@
 
     nonDerivation = callPackage ./../by-name/no/nonDerivation/package.nix { /* ... */ };
 
-  However, in this PR, the second argument is empty. See the definition in pkgs/top-level/all-packages.nix:2:
+  However, in this PR, the second argument is empty. See the definition in pkgs/top-level/all-packages.nix:1:
 
     nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { };
 

--- a/tests/override-empty-arg/pkgs/top-level/all-packages.nix
+++ b/tests/override-empty-arg/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { };
-}
+self: super: { nonDerivation = self.callPackage ./../by-name/no/nonDerivation/package.nix { }; }

--- a/tests/override-no-call-package/expected
+++ b/tests/override-no-call-package/expected
@@ -2,7 +2,7 @@
 
     nonDerivation = callPackage ./../by-name/no/nonDerivation/package.nix { /* ... */ };
 
-  However, in this PR, it isn't defined that way. See the definition in pkgs/top-level/all-packages.nix:2
+  However, in this PR, it isn't defined that way. See the definition in pkgs/top-level/all-packages.nix:1
 
     nonDerivation = self.someDrv;
 

--- a/tests/override-no-call-package/pkgs/top-level/all-packages.nix
+++ b/tests/override-no-call-package/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  nonDerivation = self.someDrv;
-}
+self: super: { nonDerivation = self.someDrv; }

--- a/tests/override-no-file/expected
+++ b/tests/override-no-file/expected
@@ -2,7 +2,7 @@
 
     nonDerivation = callPackage ./../by-name/no/nonDerivation/package.nix { /* ... */ };
 
-  However, in this PR, the first `callPackage` argument is not a path. See the definition in pkgs/top-level/all-packages.nix:2:
+  However, in this PR, the first `callPackage` argument is not a path. See the definition in pkgs/top-level/all-packages.nix:1:
 
     nonDerivation = self.callPackage ({ someDrv }: someDrv) { };
 

--- a/tests/override-no-file/pkgs/top-level/all-packages.nix
+++ b/tests/override-no-file/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  nonDerivation = self.callPackage ({ someDrv }: someDrv) { };
-}
+self: super: { nonDerivation = self.callPackage ({ someDrv }: someDrv) { }; }

--- a/tests/override-non-path/pkgs/top-level/all-packages.nix
+++ b/tests/override-non-path/pkgs/top-level/all-packages.nix
@@ -1,5 +1,4 @@
 self: super: {
 
   foo = self.callPackage ({ someDrv, someFlag }: someDrv) { someFlag = true; };
-
 }

--- a/tests/override-success/pkgs/by-name/fo/foo/package.nix
+++ b/tests/override-success/pkgs/by-name/fo/foo/package.nix
@@ -2,7 +2,4 @@
   someDrv,
   enableBar ? false,
 }:
-if enableBar then
-  someDrv
-else
-  {}
+if enableBar then someDrv else { }

--- a/tests/override-success/pkgs/top-level/all-packages.nix
+++ b/tests/override-success/pkgs/top-level/all-packages.nix
@@ -1,5 +1,1 @@
-self: super: {
-  foo = self.callPackage ./../by-name/fo/foo/package.nix {
-    enableBar = true;
-  };
-}
+self: super: { foo = self.callPackage ./../by-name/fo/foo/package.nix { enableBar = true; }; }

--- a/tests/package-variants/base/pkgs/top-level/all-packages.nix
+++ b/tests/package-variants/base/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: {
-  foo-variant-unvarianted = self.callPackage ./../by-name/fo/foo/package.nix { };
-}
+self: super: { foo-variant-unvarianted = self.callPackage ./../by-name/fo/foo/package.nix { }; }

--- a/tests/ref-absolute/expected
+++ b/tests/ref-absolute/expected
@@ -1,2 +1,2 @@
-pkgs/by-name/aa/aa: File package.nix at line 2 contains the path expression "/foo" which cannot be resolved: No such file or directory (os error 2).
+pkgs/by-name/aa/aa: File package.nix at line 1 contains the path expression "/foo" which cannot be resolved: No such file or directory (os error 2).
 This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/ref-absolute/pkgs/by-name/aa/aa/package.nix
+++ b/tests/ref-absolute/pkgs/by-name/aa/aa/package.nix
@@ -1,3 +1,1 @@
-{ someDrv }: someDrv // {
-  escape = /foo;
-}
+{ someDrv }: someDrv // { escape = /foo; }

--- a/tests/ref-escape/expected
+++ b/tests/ref-escape/expected
@@ -1,2 +1,2 @@
-pkgs/by-name/aa/aa: File package.nix at line 2 contains the path expression "../." which may point outside the directory of that package.
+pkgs/by-name/aa/aa: File package.nix at line 1 contains the path expression "../." which may point outside the directory of that package.
 This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/ref-escape/pkgs/by-name/aa/aa/package.nix
+++ b/tests/ref-escape/pkgs/by-name/aa/aa/package.nix
@@ -1,3 +1,1 @@
-{ someDrv }: someDrv // {
-  escape = ../.;
-}
+{ someDrv }: someDrv // { escape = ../.; }

--- a/tests/ref-nix-path/expected
+++ b/tests/ref-nix-path/expected
@@ -1,2 +1,2 @@
-pkgs/by-name/aa/aa: File package.nix at line 2 contains the nix search path expression "<nixpkgs>" which may point outside the directory of that package.
+pkgs/by-name/aa/aa: File package.nix at line 1 contains the nix search path expression "<nixpkgs>" which may point outside the directory of that package.
 This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/ref-nix-path/pkgs/by-name/aa/aa/package.nix
+++ b/tests/ref-nix-path/pkgs/by-name/aa/aa/package.nix
@@ -1,3 +1,1 @@
-{ someDrv }: someDrv // {
-  nixPath = <nixpkgs>;
-}
+{ someDrv }: someDrv // { nixPath = <nixpkgs>; }

--- a/tests/ref-path-subexpr/expected
+++ b/tests/ref-path-subexpr/expected
@@ -1,2 +1,2 @@
-pkgs/by-name/aa/aa: File package.nix at line 2 contains the path expression "./${"test"}", which is not yet supported and may point outside the directory of that package.
+pkgs/by-name/aa/aa: File package.nix at line 1 contains the path expression "./${"test"}", which is not yet supported and may point outside the directory of that package.
 This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/ref-path-subexpr/pkgs/by-name/aa/aa/package.nix
+++ b/tests/ref-path-subexpr/pkgs/by-name/aa/aa/package.nix
@@ -1,3 +1,1 @@
-{ someDrv }: someDrv // {
-  pathWithSubexpr = ./${"test"};
-}
+{ someDrv }: someDrv // { pathWithSubexpr = ./${"test"}; }

--- a/tests/ref-success/pkgs/by-name/aa/aa/package.nix
+++ b/tests/ref-success/pkgs/by-name/aa/aa/package.nix
@@ -1,4 +1,6 @@
-{ someDrv }: someDrv // {
+{ someDrv }:
+someDrv
+// {
   nixFile = ./file.nix;
   nonNixFile = ./file;
   directory = ./dir;

--- a/tests/unknown-location/pkgs/top-level/all-packages.nix
+++ b/tests/unknown-location/pkgs/top-level/all-packages.nix
@@ -1,3 +1,1 @@
-self: super: builtins.mapAttrs (name: value: value) {
-  foo = self.someDrv;
-}
+self: super: builtins.mapAttrs (name: value: value) { foo = self.someDrv; }


### PR DESCRIPTION
Prompted by https://github.com/NixOS/nixpkgs-check-by-name/pull/46#discussion_r1566745927 (cc @willbush). I didn't use a bash formatter, but https://github.com/lovesegfault/beautysh seems to almost match what I've been doing!

For Nix formatting we obviously use https://github.com/NixOS/nixfmt :)