### PR TITLE
Fix cargo missing in dev env

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
     settings.formatter.shfmt.options = [ "--space-redirects" ];
   };
 
-  results = {
+  packages = {
     build = pkgs.callPackage ./package.nix {
       inherit
         nixpkgsLibPath
@@ -60,7 +60,7 @@ let
       env.NIX_CHECK_BY_NAME_EXPR_PATH = toString runtimeExprPath;
       env.NIX_PATH = "test-nixpkgs=${toString testNixpkgsPath}:test-nixpkgs/lib=${toString nixpkgsLibPath}";
       env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
-      inputsFrom = [ results.build ];
+      inputsFrom = [ packages.build ];
       nativeBuildInputs = with pkgs; [
         npins
         rust-analyzer
@@ -135,7 +135,7 @@ let
       pkgs.runCommand "test-nixpkgs-check-by-name"
         {
           nativeBuildInputs = [
-            results.build
+            packages.build
             pkgs.nix
           ];
           nixpkgsPath = nixpkgs;
@@ -147,14 +147,14 @@ let
         '';
   };
 in
-results
+packages
 // {
 
   # Good for debugging
   inherit pkgs;
 
   # Built by CI
-  ci = pkgs.linkFarm "ci" results;
+  ci = pkgs.linkFarm "ci" packages;
 
   # Used by CI to determine whether a new version should be released
   inherit version;


### PR DESCRIPTION
<s>No idea how I didn't notice it missing before..

Must've come from somewhere else :shrug:</s>

Turns out `lazyDerivation` (added in https://github.com/NixOS/nixpkgs-check-by-name/pull/40/commits/3f361a461c259b738ad8914749c0ea24ff0ca018) ended up filtering out .nativeBuildInputs and co., which mkShell's inputsFrom relies on to figure out what to use for the environment.. :facepalm: 