### PR TITLE
Fix link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,5 +65,5 @@ Integration tests are declared in [`./tests`](./tests) as subdirectories imitati
 
 Pinned dependencies are [regularly updated automatically](./.github/workflows/update.yml).
 
-Releases are [automatically created](./.github/workflows/release.yml) when the `version` field in [`Cargo.toml`](./Cargo.toml)
+Releases are [automatically created](./.github/workflows/after-release.yml) when the `version` field in [`Cargo.toml`](./Cargo.toml)
 is updated from a push to the main branch.


### PR DESCRIPTION
I didn't notice xref was failing for a valid reason when merging https://github.com/NixOS/nixpkgs-check-by-name/pull/54

Decided to point at the release.sh which publishes the release.