### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -411,18 +411,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2021"
 
 [dependencies]
 rnix = "0.11.0"
-regex = "1.9.3"
-clap = { version = "4.3.23", features = ["derive"] }
-serde_json = "1.0.105"
-tempfile = "3.8.0"
-serde = { version = "1.0.185", features = ["derive"] }
+regex = "1.10.4"
+clap = { version = "4.5.4", features = ["derive"] }
+serde_json = "1.0.117"
+tempfile = "3.10.1"
+serde = { version = "1.0.201", features = ["derive"] }
 anyhow = "1.0"
 lazy_static = "1.4.0"
-colored = "2.0.4"
-itertools = "0.11.0"
-rowan = "0.15.11"
-indoc = "2.0.4"
-relative-path = "1.9.2"
+colored = "2.1.0"
+itertools = "0.12.1"
+rowan = "0.15.15"
+indoc = "2.0.5"
+relative-path = "1.9.3"
 textwrap = "0.16.1"
 
 [dev-dependencies]
-temp-env = "0.3.5"
+temp-env = "0.3.6"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre622008.ee4a6e0f566f/nixexprs.tar.xz",
-      "hash": "0pa8g6a8xg03pbqc98vm36cffjpk5ihmfa43vms86zb4xc1hq1n4"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre624838.af8b9db5c00f/nixexprs.tar.xz",
+      "hash": "1pymzrxmmlxd983cf8kdkdva4sn8r91qpfi1hd0yzh5xx073k1nv"
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
<details><summary>cargo changes</summary>

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name          old req compatible latest  new req
====          ======= ========== ======  =======
regex         1.9.3   1.10.4     1.10.4  1.10.4 
clap          4.3.23  4.5.4      4.5.4   4.5.4  
serde_json    1.0.105 1.0.117    1.0.117 1.0.117
tempfile      3.8.0   3.10.1     3.10.1  3.10.1 
serde         1.0.185 1.0.201    1.0.201 1.0.201
colored       2.0.4   2.1.0      2.1.0   2.1.0  
itertools     0.11.0  0.11.0     0.12.1  0.12.1 
rowan         0.15.11 0.15.15    0.15.15 0.15.15
indoc         2.0.4   2.0.5      2.0.5   2.0.5  
relative-path 1.9.2   1.9.3      1.9.3   1.9.3  
temp-env      0.3.5   0.3.6      0.3.6   0.3.6  
   Upgrading recursive dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 4 packages
```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre622008.ee4a6e0f566f/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre624838.af8b9db5c00f/nixexprs.tar.xz
-    hash: 0pa8g6a8xg03pbqc98vm36cffjpk5ihmfa43vms86zb4xc1hq1n4
+    hash: 1pymzrxmmlxd983cf8kdkdva4sn8r91qpfi1hd0yzh5xx073k1nv
[INFO ] Updating 'treefmt-nix' …
(no changes)
[INFO ] Update successful.
```
</details>
