### PR TITLE
Automated update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@V27
 
       - name: build
         run: nix-build -A ci

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           path: repo
 
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@V27
 
       - name: Run update script
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -411,18 +411,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ regex = "1.10.4"
 clap = { version = "4.5.4", features = ["derive"] }
 serde_json = "1.0.117"
 tempfile = "3.10.1"
-serde = { version = "1.0.201", features = ["derive"] }
+serde = { version = "1.0.202", features = ["derive"] }
 anyhow = "1.0"
 lazy_static = "1.4.0"
 colored = "2.1.0"
-itertools = "0.12.1"
+itertools = "0.13.0"
 rowan = "0.15.15"
 indoc = "2.0.5"
 relative-path = "1.9.3"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre626139.abd6d48f8c77/nixexprs.tar.xz",
-      "hash": "1zl76mia6iav9byczjxw3lhr6hv7an4nk2kh440gpr9lqx2j446k"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre628535.f9256de8281f/nixexprs.tar.xz",
+      "hash": "11lg3hq9hz2hmk615c65vjsg1j122661k1n3by5wr5fyrzr4yp4a"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
-      "url": "https://github.com/numtide/treefmt-nix/archive/c6aaf729f34a36c445618580a9f95a48f5e4e03f.tar.gz",
-      "hash": "18491j2law88zdkfxrpg2snbcig34pfcg7ykgjwf6ahbdq313zj2"
+      "revision": "2fba33a182602b9d49f0b2440513e5ee091d838b",
+      "url": "https://github.com/numtide/treefmt-nix/archive/2fba33a182602b9d49f0b2440513e5ee091d838b.tar.gz",
+      "hash": "163ra7ck07maamg20ppqlsn8mjrf6jrn0g81334pvsfa1wr8g6n0"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name      old req compatible latest  new req
====      ======= ========== ======  =======
serde     1.0.201 1.0.202    1.0.202 1.0.202
itertools 0.12.1  0.12.1     0.13.0  0.13.0 
   Upgrading recursive dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 13 packages
```
</details>
<details><summary>GitHub Action updates</summary>

Bumps the actions group with 1 update: [cachix/install-nix-action](https://github.com/cachix/install-nix-action).

Updates `cachix/install-nix-action` from 26 to 27
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/cachix/install-nix-action/releases">cachix/install-nix-action's releases</a>.</em></p>
<blockquote>
<h2>v27</h2>
<h2>What's Changed</h2>
<ul>
<li>Enable <code>always-allow-substitutes</code> by default by <a href="https://github.com/sandydoo"><code>@​sandydoo</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/207">cachix/install-nix-action#207</a></li>
<li>nix: 2.20.5 -&gt; 2.22.1 by <a href="https://github.com/kashw2"><code>@​kashw2</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/206">cachix/install-nix-action#206</a></li>
<li>ci: fix tests by <a href="https://github.com/sandydoo"><code>@​sandydoo</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/208">cachix/install-nix-action#208</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/kashw2"><code>@​kashw2</code></a> made their first contribution in <a href="https://redirect.github.com/cachix/install-nix-action/pull/206">cachix/install-nix-action#206</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/cachix/install-nix-action/compare/v26...V27">https://github.com/cachix/install-nix-action/compare/v26...V27</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/cachix/install-nix-action/commit/ba0dd844c9180cbf77aa72a116d6fbc515d0e87b"><code>ba0dd84</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/208">#208</a> from cachix/fix-macos-tests</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/d9660bf088514a2ede4707708ba35de0a1b69a3d"><code>d9660bf</code></a> ci: updated pinned installer</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/1e14eb01bfd97127cae3cc76eddb538ed44af120"><code>1e14eb0</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/206">#206</a> from kashw2/nix-update</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/6060e02b1f9cb669240905a2db3fa1d327692d44"><code>6060e02</code></a> 2.22.1</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/262815eb715530d99d468e099f9c53a1d7557fda"><code>262815e</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/207">#207</a> from cachix/always-allow-substitutes</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/5dce380a8bcabd02812ffac2471c6a4f5a470c7c"><code>5dce380</code></a> Update README with more installer differences</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/2f469017fc567f1b7fe6d1d7c21021c02ad55105"><code>2f46901</code></a> ci: update nixpkgs channel</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/529d65921746c2b43d8a8a0458544a4a51f6ddc3"><code>529d659</code></a> ci: add aarch64-darwin tests where possible</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/d6c2f5b78803207e177e2f3d3d2d2899df69c6f2"><code>d6c2f5b</code></a> ci: switch to macos-13</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/01dba9f77095b5f03102533169760a81c51f2205"><code>01dba9f</code></a> Update README</li>
<li>Additional commits viewable in <a href="https://github.com/cachix/install-nix-action/compare/v26...V27">compare view</a></li>
</ul>
</details>
<br />

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre626139.abd6d48f8c77/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre628535.f9256de8281f/nixexprs.tar.xz
-    hash: 1zl76mia6iav9byczjxw3lhr6hv7an4nk2kh440gpr9lqx2j446k
+    hash: 11lg3hq9hz2hmk615c65vjsg1j122661k1n3by5wr5fyrzr4yp4a
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: c6aaf729f34a36c445618580a9f95a48f5e4e03f
+    revision: 2fba33a182602b9d49f0b2440513e5ee091d838b
-    url: https://github.com/numtide/treefmt-nix/archive/c6aaf729f34a36c445618580a9f95a48f5e4e03f.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/2fba33a182602b9d49f0b2440513e5ee091d838b.tar.gz
-    hash: 18491j2law88zdkfxrpg2snbcig34pfcg7ykgjwf6ahbdq313zj2
+    hash: 163ra7ck07maamg20ppqlsn8mjrf6jrn0g81334pvsfa1wr8g6n0
[INFO ] Update successful.
```
</details>
