### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre631646.e2dd4e18cc1c/nixexprs.tar.xz",
-      "hash": "0mfb3ky0ylc5hlm9m1bzxy7r4p2j7g1mgh1ymwd94nd5m7gcl81b"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre633168.6132b0f6e344/nixexprs.tar.xz",
+      "hash": "0jli5364mw57krjc9csswc3xh1bvbjcv85hf81l9gx7fcp5qkswa"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "2fba33a182602b9d49f0b2440513e5ee091d838b",
-      "url": "https://github.com/numtide/treefmt-nix/archive/2fba33a182602b9d49f0b2440513e5ee091d838b.tar.gz",
-      "hash": "163ra7ck07maamg20ppqlsn8mjrf6jrn0g81334pvsfa1wr8g6n0"
+      "revision": "3eb96ca1ae9edf792a8e0963cc92fddfa5a87706",
+      "url": "https://github.com/numtide/treefmt-nix/archive/3eb96ca1ae9edf792a8e0963cc92fddfa5a87706.tar.gz",
+      "hash": "0g6cf61klla9zp50xwcfvi7m4ngni7wn6wwc5s7239ibsq6ilpdv"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
    Updating proc-macro2 v1.0.84 -> v1.0.85

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 628 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre631646.e2dd4e18cc1c/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre633168.6132b0f6e344/nixexprs.tar.xz
-    hash: 0mfb3ky0ylc5hlm9m1bzxy7r4p2j7g1mgh1ymwd94nd5m7gcl81b
+    hash: 0jli5364mw57krjc9csswc3xh1bvbjcv85hf81l9gx7fcp5qkswa
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 2fba33a182602b9d49f0b2440513e5ee091d838b
+    revision: 3eb96ca1ae9edf792a8e0963cc92fddfa5a87706
-    url: https://github.com/numtide/treefmt-nix/archive/2fba33a182602b9d49f0b2440513e5ee091d838b.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/3eb96ca1ae9edf792a8e0963cc92fddfa5a87706.tar.gz
-    hash: 163ra7ck07maamg20ppqlsn8mjrf6jrn0g81334pvsfa1wr8g6n0
+    hash: 0g6cf61klla9zp50xwcfvi7m4ngni7wn6wwc5s7239ibsq6ilpdv
[INFO ] Update successful.
```
</details>
