### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags",
 ]

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre636874.3bcedce9f4de/nixexprs.tar.xz",
-      "hash": "0ddrh45mvy293x10irvfm1ypd6w6rinm3cnd9laiiqvnq0v0y8lf"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre639552.e6cea36f8349/nixexprs.tar.xz",
+      "hash": "0pii8c6wlh7wc6wxwhc85nyn3pk00qi3kn3jah2agf87cbmm9qdk"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "4fc1c45a5f50169f9f29f6a98a438fb910b834ed",
-      "url": "https://github.com/numtide/treefmt-nix/archive/4fc1c45a5f50169f9f29f6a98a438fb910b834ed.tar.gz",
-      "hash": "10gir0qy045c8gjrz1jip5zfk9ypz1p59rvaklqqm4wn1xb2m5ly"
+      "revision": "68eb1dc333ce82d0ab0c0357363ea17c31ea1f81",
+      "url": "https://github.com/numtide/treefmt-nix/archive/68eb1dc333ce82d0ab0c0357363ea17c31ea1f81.tar.gz",
+      "hash": "0nsf69jw6kd5ffi86icack0lqlhq51v67pnq8s5yh10s64myig2h"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
    Updating memchr v2.7.2 -> v2.7.4
    Updating redox_syscall v0.5.1 -> v0.5.2

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 628 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre636874.3bcedce9f4de/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre639552.e6cea36f8349/nixexprs.tar.xz
-    hash: 0ddrh45mvy293x10irvfm1ypd6w6rinm3cnd9laiiqvnq0v0y8lf
+    hash: 0pii8c6wlh7wc6wxwhc85nyn3pk00qi3kn3jah2agf87cbmm9qdk
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 4fc1c45a5f50169f9f29f6a98a438fb910b834ed
+    revision: 68eb1dc333ce82d0ab0c0357363ea17c31ea1f81
-    url: https://github.com/numtide/treefmt-nix/archive/4fc1c45a5f50169f9f29f6a98a438fb910b834ed.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/68eb1dc333ce82d0ab0c0357363ea17c31ea1f81.tar.gz
-    hash: 10gir0qy045c8gjrz1jip5zfk9ypz1p59rvaklqqm4wn1xb2m5ly
+    hash: 0nsf69jw6kd5ffi86icack0lqlhq51v67pnq8s5yh10s64myig2h
[INFO ] Update successful.
```
</details>
