### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -460,9 +460,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1.0.117"
 tempfile = "3.10.1"
 serde = { version = "1.0.203", features = ["derive"] }
 anyhow = "1.0"
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 colored = "2.1.0"
 itertools = "0.13.0"
 rowan = "0.15.15"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre639552.e6cea36f8349/nixexprs.tar.xz",
-      "hash": "0pii8c6wlh7wc6wxwhc85nyn3pk00qi3kn3jah2agf87cbmm9qdk"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre642670.9693852a2070/nixexprs.tar.xz",
+      "hash": "0742ps99c1nfqv2ahz0g964p38jyflzjpaxh7h7sjj847h0chiwg"
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name        old req compatible latest new req
====        ======= ========== ====== =======
lazy_static 1.4.0   1.5.0      1.5.0  1.5.0  
   Upgrading recursive dependencies
note: pass `--verbose` to see 9 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 14 packages

```
### cargo update

```
    Updating crates.io index
    Updating proc-macro2 v1.0.85 -> v1.0.86
    Updating syn v2.0.66 -> v2.0.68
note: pass `--verbose` to see 11 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 629 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre639552.e6cea36f8349/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre642670.9693852a2070/nixexprs.tar.xz
-    hash: 0pii8c6wlh7wc6wxwhc85nyn3pk00qi3kn3jah2agf87cbmm9qdk
+    hash: 0742ps99c1nfqv2ahz0g964p38jyflzjpaxh7h7sjj847h0chiwg
[INFO ] Updating 'treefmt-nix' …
(no changes)
[INFO ] Update successful.
```
</details>
