### PR TITLE
README.md: update the gzip link to avoid the flaky gnu.org server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ nix-build https://github.com/NixOS/nixpkgs-check-by-name/tarball/master -A build
 ## Prebuilt store paths
 
 The [GitHub releases](https://github.com/NixOS/nixpkgs-check-by-name/releases)
-contain a [gzip](https://www.gnu.org/software/gzip/)-compressed
+contain a [gzip](https://en.wikipedia.org/wiki/Gzip)-compressed
 [Nix Archive](https://nixos.org/manual/nix/stable/command-ref/nix-store/export.html)
 of the [build closure](https://nixos.org/manual/nix/stable/glossary#gloss-closure)
 of the [Nix derivation](#nix-derivations) with `x86_64-linux` as the `system`.


### PR DESCRIPTION
See [this check log](https://github.com/NixOS/nixpkgs-check-by-name/commit/d3a133933df2f88f09c1b9344791aca1efc3f90c/checks/26610653723/logs) for an example of the failures that can result.