### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cfg-if"
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -148,9 +148,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "errno"
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "e8eddb61f0697cc3989c5d64b452f5488e2b8a60fd7d5076a3045076ffef8cb0"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.10.5"
-clap = { version = "4.5.7", features = ["derive"] }
-serde_json = "1.0.117"
+clap = { version = "4.5.8", features = ["derive"] }
+serde_json = "1.0.119"
 tempfile = "3.10.1"
 serde = { version = "1.0.203", features = ["derive"] }
 anyhow = "1.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre642670.9693852a2070/nixexprs.tar.xz",
-      "hash": "0742ps99c1nfqv2ahz0g964p38jyflzjpaxh7h7sjj847h0chiwg"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre645735.12a9c0004bc9/nixexprs.tar.xz",
+      "hash": "17py5ah7l7hya9y33vch86d1ws0z1v2s7mffi11vb4fgy5maim55"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "68eb1dc333ce82d0ab0c0357363ea17c31ea1f81",
-      "url": "https://github.com/numtide/treefmt-nix/archive/68eb1dc333ce82d0ab0c0357363ea17c31ea1f81.tar.gz",
-      "hash": "0nsf69jw6kd5ffi86icack0lqlhq51v67pnq8s5yh10s64myig2h"
+      "revision": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
+      "url": "https://github.com/numtide/treefmt-nix/archive/8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd.tar.gz",
+      "hash": "1j0wdm3azk7nsh60n0wf2192i26paby74gsp902j4a4sr8fwmlvm"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
clap       4.5.7   4.5.8      4.5.8   4.5.8  
serde_json 1.0.117 1.0.119    1.0.119 1.0.119
   Upgrading recursive dependencies
note: pass `--verbose` to see 9 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 13 packages

```
### cargo update

```
    Updating crates.io index
    Updating bitflags v2.5.0 -> v2.6.0
    Updating either v1.12.0 -> v1.13.0
note: pass `--verbose` to see 11 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 630 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre642670.9693852a2070/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre645735.12a9c0004bc9/nixexprs.tar.xz
-    hash: 0742ps99c1nfqv2ahz0g964p38jyflzjpaxh7h7sjj847h0chiwg
+    hash: 17py5ah7l7hya9y33vch86d1ws0z1v2s7mffi11vb4fgy5maim55
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 68eb1dc333ce82d0ab0c0357363ea17c31ea1f81
+    revision: 8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd
-    url: https://github.com/numtide/treefmt-nix/archive/68eb1dc333ce82d0ab0c0357363ea17c31ea1f81.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd.tar.gz
-    hash: 0nsf69jw6kd5ffi86icack0lqlhq51v67pnq8s5yh10s64myig2h
+    hash: 1j0wdm3azk7nsh60n0wf2192i26paby74gsp902j4a4sr8fwmlvm
[INFO ] Update successful.
```
</details>
