### PR TITLE
Inconsequential comment manipulation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,6 +67,7 @@ let
         cargo-outdated
         npins
         rust-analyzer
+        rustfmt
         treefmtEval.config.build.wrapper
       ];
     };

--- a/src/eval.nix
+++ b/src/eval.nix
@@ -1,15 +1,14 @@
 # Takes a path to nixpkgs and a path to the json-encoded list of `pkgs/by-name` attributes.
-# Returns a value containing information on all Nixpkgs attributes
-# which is decoded on the Rust side.
-# See ./eval.rs for the meaning of the returned values
+#
+# Returns a value containing information on all Nixpkgs attributes which is decoded on the Rust
+# side. See ./eval.rs for the meaning of the returned values.
 { attrsPath, nixpkgsPath }:
 let
   attrs = builtins.fromJSON (builtins.readFile attrsPath);
 
-  # We need to check whether attributes are defined manually e.g. in
-  # `all-packages.nix`, automatically by the `pkgs/by-name` overlay, or
-  # neither. The only way to do so is to override `callPackage` and
-  # `_internalCallByNamePackageFile` with our own version that adds this
+  # We need to check whether attributes are defined manually e.g. in `all-packages.nix`,
+  # automatically by the `pkgs/by-name` overlay, or neither. The only way to do so is to override
+  # `callPackage` and `_internalCallByNamePackageFile` with our own version that adds this
   # information to the result, and then try to access it.
   overlay = final: prev: {
 
@@ -17,41 +16,41 @@ let
     callPackage =
       fn: args:
       addVariantInfo (prev.callPackage fn args) {
-        # This is a manual definition of the attribute, and it's a callPackage, specifically a semantic callPackage
+        # This is a manual definition of the attribute, and it's a `1callPackage`, specifically a
+        # semantic `callPackage`.
         ManualDefinition.is_semantic_call_package = true;
       };
 
-    # Adds information to each attribute about whether it's automatically
-    # defined by the `pkgs/by-name` overlay. This internal attribute is only
-    # used by that overlay.
-    # This overrides the above `callPackage` information (we don't need that
-    # one, since `pkgs/by-name` always uses `callPackage` underneath.
+    # Adds information to each attribute about whether it's automatically defined by the
+    # `pkgs/by-name` overlay. This internal attribute is only used by that overlay.
+    #
+    # This overrides the above `callPackage` information. It's OK because we don't need that one,
+    # since `pkgs/by-name` always uses `callPackage` underneath.
     _internalCallByNamePackageFile =
       file: addVariantInfo (prev._internalCallByNamePackageFile file) { AutoDefinition = null; };
   };
 
-  # We can't just replace attribute values with their info in the overlay,
-  # because attributes can depend on other attributes, so this would break evaluation.
+  # We can't just replace attribute values with their info in the overlay, because attributes can
+  # depend on other attributes, so this would break evaluation.
   addVariantInfo =
     value: variant:
     if builtins.isAttrs value then
       value // { _callPackageVariant = variant; }
     else
-      # It's very rare that callPackage doesn't return an attribute set, but it can occur.
-      # In such a case we can't really return anything sensible that would include the info,
-      # so just don't return the value directly and treat it as if it wasn't a callPackage.
+      # It's very rare that `callPackage` doesn't return an attribute set, but it can occur.
+      # In such a case we can't really return anything sensible that would include the info, so just
+      # don't return the value directly and treat it as if it wasn't a `callPackage`.
       value;
 
   pkgs = import nixpkgsPath {
-    # Don't let the users home directory influence this result
+    # Don't let the user's home directory influence this result.
     config = { };
     overlays = [ overlay ];
-    # We check evaluation and callPackage only for x86_64-linux.
-    # Not ideal, but hard to fix
+    # We check evaluation and `callPackage` only for x86_64-linux.  Not ideal, but hard to fix.
     system = "x86_64-linux";
   };
 
-  # See AttributeInfo in ./eval.rs for the meaning of this
+  # See AttributeInfo in ./eval.rs for the meaning of this.
   attrInfo = name: value: {
     location = builtins.unsafeGetAttrPos name pkgs;
     attribute_variant =
@@ -70,7 +69,7 @@ let
         };
   };
 
-  # Information on all attributes that are in pkgs/by-name.
+  # Information on all attributes that are in `pkgs/by-name`.
   byNameAttrs = builtins.listToAttrs (
     map (name: {
       inherit name;
@@ -78,18 +77,17 @@ let
         if !pkgs ? ${name} then
           { Missing = null; }
         else
-          # Evaluation failures are not allowed, so don't try to catch them
+          # Evaluation failures are not allowed, so don't try to catch them.
           { Existing = attrInfo name pkgs.${name}; };
     }) attrs
   );
 
-  # Information on all attributes that exist but are not in pkgs/by-name.
-  # We need this to enforce pkgs/by-name for new packages
+  # Information on all attributes that exist but are not in `pkgs/by-name`.
+  # We need this to enforce `pkgs/by-name` for new packages.
   nonByNameAttrs = builtins.mapAttrs (
     name: value:
     let
-      # Packages outside `pkgs/by-name` often fail evaluation,
-      # so we need to handle that
+      # Packages outside `pkgs/by-name` often fail evaluation, so we need to handle that.
       output = attrInfo name value;
       result = builtins.tryEval (builtins.deepSeq output null);
     in
@@ -101,8 +99,8 @@ let
   # All attributes
   attributes = byNameAttrs // nonByNameAttrs;
 in
-# We output them in the form [ [ <name> <value> ] ]` such that the Rust side
-# doesn't need to sort them again to get deterministic behavior (good for testing)
+# We output them in the form [ [ <name> <value> ] ]` such that the Rust side doesn't need to sort
+# them again to get deterministic behavior. This is good for testing.
 map (name: [
   name
   attributes.${name}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use std::thread;
 
 /// Program to check the validity of pkgs/by-name
 ///
-/// This CLI interface may be changed over time if the CI workflow making use of
-/// it is adjusted to deal with the change appropriately.
+/// This CLI interface may be changed over time if the CI workflow making use of it is adjusted to
+/// deal with the change appropriately.
 ///
 /// Exit code:
 /// - `0`: If the validation is successful
@@ -36,12 +36,11 @@ use std::thread;
 #[derive(Parser, Debug)]
 #[command(about, verbatim_doc_comment)]
 pub struct Args {
-    /// Path to the main Nixpkgs to check.
-    /// For PRs, this should be set to a checkout of the PR branch.
+    /// Path to the main Nixpkgs to check. For PRs, set this to a checkout of the PR branch.
     nixpkgs: PathBuf,
 
     /// Path to the base Nixpkgs to run ratchet checks against.
-    /// For PRs, this should be set to a checkout of the PRs base branch.
+    /// For PRs, set this to a checkout of the PRs base branch.
     #[arg(long)]
     base: PathBuf,
 }
@@ -88,11 +87,19 @@ pub fn process<W: io::Write>(
 
     match (base_result, main_result) {
         (Failure(_), Failure(errors)) => {
-            // Base branch fails and the PR doesn't fix it and may also introduce additional problems
+            // The base branch fails, the PR doesn't fix it, and the PR may also introduce
+            // additional problems.
             for error in errors {
                 writeln!(error_writer, "{}", error.to_string().red())?
             }
-            writeln!(error_writer, "{}", "The base branch is broken and still has above problems with this PR, which need to be fixed first.\nConsider reverting the PR that introduced these problems in order to prevent more failures of unrelated PRs.".yellow())?;
+            writeln!(
+                error_writer,
+                "{}",
+                "The base branch is broken and still has above problems with this PR, \
+                which need to be fixed first.\nConsider reverting the PR that introduced \
+                these problems in order to prevent more failures of unrelated PRs."
+                    .yellow()
+            )?;
             Ok(false)
         }
         (Failure(_), Success(_)) => {
@@ -110,7 +117,8 @@ pub fn process<W: io::Write>(
             writeln!(
                 error_writer,
                 "{}",
-                "This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break."
+                "This PR introduces the problems listed above. \
+                Please fix them before merging, otherwise the base branch would break."
                     .yellow()
             )?;
             Ok(false)
@@ -122,7 +130,13 @@ pub fn process<W: io::Write>(
                     for error in errors {
                         writeln!(error_writer, "{}", error.to_string().red())?
                     }
-                    writeln!(error_writer, "{}", "This PR introduces additional instances of discouraged patterns as listed above. Merging is discouraged but would not break the base branch.".yellow())?;
+                    writeln!(
+                        error_writer,
+                        "{}",
+                        "This PR introduces additional instances of discouraged patterns as \
+                        listed above. Merging is discouraged but would not break the base branch."
+                            .yellow()
+                    )?;
 
                     Ok(false)
                 }
@@ -197,8 +211,8 @@ mod tests {
         Ok(temp_env::with_vars(empty_list, tempfile::tempdir)?)
     }
 
-    // We cannot check case-conflicting files into Nixpkgs (the channel would fail to
-    // build), so we generate the case-conflicting file instead.
+    // We cannot check case-conflicting files into Nixpkgs (the channel would fail to build),
+    // so we generate the case-conflicting file instead.
     #[test]
     fn test_case_sensitive() -> anyhow::Result<()> {
         let temp_nixpkgs = tempdir()?;
@@ -220,19 +234,23 @@ mod tests {
         test_nixpkgs(
             "case_sensitive",
             path,
-            "pkgs/by-name/fo: Duplicate case-sensitive package directories \"foO\" and \"foo\".\nThis PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.\n",
+            "pkgs/by-name/fo: Duplicate case-sensitive package directories \"foO\" and \"foo\".\n\
+            This PR introduces the problems listed above. Please fix them before merging, \
+            otherwise the base branch would break.\n",
         )?;
 
         Ok(())
     }
 
     /// Tests symlinked temporary directories.
-    /// This is needed because on darwin, `/tmp` is a symlink to `/private/tmp`, and Nix's
+    ///
+    /// This is needed because on Darwin, `/tmp` is a symlink to `/private/tmp`, and Nix's
     /// restrict-eval doesn't also allow access to the canonical path when you allow the
     /// non-canonical one.
     ///
     /// The error if we didn't do this would look like this:
-    /// error: access to canonical path '/private/var/folders/[...]/.tmpFbcNO0' is forbidden in restricted mode
+    /// error: access to canonical path
+    /// '/private/var/folders/[...]/.tmpFbcNO0' is forbidden in restricted mode
     #[test]
     fn test_symlinked_tmpdir() -> anyhow::Result<()> {
         // Create a directory with two entries:
@@ -277,7 +295,8 @@ mod tests {
 
         if actual_errors != expected_errors {
             panic!(
-                "Failed test case {name}, expected these errors:\n=======\n{}\n=======\nbut got these:\n=======\n{}\n=======",
+                "Failed test case {name}, expected these errors:\n=======\n{}\n=======\n\
+                but got these:\n=======\n{}\n=======",
                 expected_errors, actual_errors
             );
         }

--- a/src/references.rs
+++ b/src/references.rs
@@ -20,8 +20,8 @@ pub fn check_references(
 ) -> validation::Result<()> {
     // The first subpath to check is the package directory itself, which we can represent as an
     // empty path, since the absolute package directory gets prepended to this.
-    // We don't use `./.` to keep the error messages cleaner
-    // (there's no canonicalisation going on underneath)
+    // We don't use `./.` to keep the error messages cleaner, since there's no canonicalisation
+    // going on underneath.
     let subpath = RelativePath::new("");
     check_path(
         nix_file_store,
@@ -37,7 +37,7 @@ pub fn check_references(
     })
 }
 
-/// Checks for a specific path to not have references outside
+/// Checks for a specific path to not have references outside.
 ///
 /// The subpath is the relative path within the package directory we're currently checking.
 /// A relative path so that the error messages don't get absolute paths (which are messy in CI).
@@ -59,11 +59,11 @@ fn check_path(
     };
 
     Ok(if path.is_symlink() {
-        // Check whether the symlink resolves to outside the package directory
+        // Check whether the symlink resolves to outside the package directory.
         match path.canonicalize() {
             Ok(target) => {
-                // No need to handle the case of it being inside the directory, since we scan through the
-                // entire directory recursively anyways
+                // No need to handle the case of it being inside the directory, since we scan
+                // through the entire directory recursively in any case.
                 if let Err(_prefix_error) = target.strip_prefix(absolute_package_dir) {
                     to_validation(PathErrorKind::OutsideSymlink)
                 } else {
@@ -114,8 +114,8 @@ fn check_path(
     })
 }
 
-/// Check whether a nix file contains path expression references pointing outside the package
-/// directory
+/// Check whether a Nix file contains path expression references pointing outside the package
+/// directory.
 fn check_nix_file(
     nix_file_store: &mut NixFileStore,
     relative_package_dir: &RelativePath,
@@ -159,8 +159,8 @@ fn check_nix_file(
                     })
                 }
                 ResolvedPath::Within(..) => {
-                    // No need to handle the case of it being inside the directory, since we scan through the
-                    // entire directory recursively anyways
+                    // No need to handle the case of it being inside the directory, since we scan
+                    // through the entire directory recursively in any case.
                     Success(())
                 }
             }

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -52,7 +52,6 @@ pub fn check_structure(
 
             Ok(if shard_name == "README.md" {
                 // README.md is allowed to be a file and not checked
-
                 Success(vec![])
             } else if !shard_path.is_dir() {
                 NixpkgsProblem::Shard(ShardError {
@@ -60,7 +59,8 @@ pub fn check_structure(
                     kind: ShardErrorKind::ShardNonDir,
                 })
                 .into()
-                // we can't check for any other errors if it's a file, since there's no subdirectories to check
+                // We can't check for any other errors if it's a file, since there's no
+                // subdirectories to check.
             } else {
                 let shard_name_valid = SHARD_NAME_REGEX.is_match(&shard_name);
                 let result = if !shard_name_valid {
@@ -112,7 +112,7 @@ pub fn check_structure(
         })
         .collect_vec()?;
 
-    // Combine the package names conatained within each shard into a longer list
+    // Combine the package names contained within each shard into a longer list.
     Ok(validation::sequence(shard_results).map(concat))
 }
 
@@ -153,8 +153,8 @@ fn check_package(
 
         let correct_relative_package_dir = relative_dir_for_package(&package_name);
         let result = result.and(if relative_package_dir != correct_relative_package_dir {
-            // Only show this error if we have a valid shard and package name
-            // Because if one of those is wrong, you should fix that first
+            // Only show this error if we have a valid shard and package name. If one of those is
+            // wrong, you should fix that first.
             if shard_name_valid && package_name_valid {
                 to_validation(PackageErrorKind::IncorrectShard {
                     correct_relative_package_dir: correct_relative_package_dir.clone(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,22 +6,25 @@ use std::path::Path;
 pub const BASE_SUBPATH: &str = "pkgs/by-name";
 pub const PACKAGE_NIX_FILENAME: &str = "package.nix";
 
-/// Deterministic file listing so that tests are reproducible
+/// Deterministic file listing so that tests are reproducible.
 pub fn read_dir_sorted(base_dir: &Path) -> anyhow::Result<Vec<fs::DirEntry>> {
     let listing = base_dir
         .read_dir()
         .with_context(|| format!("Could not list directory {}", base_dir.display()))?;
+
     let mut shard_entries = listing
         .collect::<io::Result<Vec<_>>>()
         .with_context(|| format!("Could not list directory {}", base_dir.display()))?;
+
     shard_entries.sort_by_key(|entry| entry.file_name());
+
     Ok(shard_entries)
 }
 
 /// A simple utility for calculating the line for a string offset.
-/// This doesn't do any Unicode handling, though that probably doesn't matter
-/// because newlines can't split up Unicode characters. Also this is only used
-/// for error reporting
+///
+/// This doesn't do any Unicode handling, though that probably doesn't matter because newlines
+/// can't split up Unicode characters. This is only used for error reporting.
 pub struct LineIndex {
     /// Stores the indices of newlines
     newlines: Vec<usize>,
@@ -41,7 +44,7 @@ impl LineIndex {
     }
 
     /// Returns the line number for a string index.
-    /// If the index points to a newline, returns the line number before the newline
+    /// If the index points to a newline, returns the line number before the newline.
     pub fn line(&self, index: usize) -> usize {
         match self.newlines.binary_search(&index) {
             // +1 because lines are 1-indexed
@@ -60,7 +63,7 @@ impl LineIndex {
             // For the nth line, we add the index of the (n-1)st newline to the column,
             // and remove one more from the index since arrays are 0-indexed.
             // Then add the 1-indexed column to get not the newline index itself,
-            // but rather the index of the position on the next line
+            // but rather the index of the position on the next line.
             self.newlines[line - 2] + column
         }
     }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -6,12 +6,11 @@ use itertools::{
 };
 use Validation::*;
 
-/// The validation result of a check.
-/// Instead of exiting at the first failure,
-/// this type can accumulate multiple failures.
-/// This can be achieved using the functions `and`, `sequence` and `sequence_`
+/// The validation result of a check.  Instead of exiting at the first failure, this type can
+/// accumulate multiple failures.  This can be achieved using the functions `and`, `sequence` and
+/// `sequence_`.
 ///
-/// This leans on https://hackage.haskell.org/package/validation
+/// This leans on <https://hackage.haskell.org/package/validation>.
 pub enum Validation<A> {
     Failure(Vec<NixpkgsProblem>),
     Success(A),
@@ -25,14 +24,18 @@ impl<A> From<NixpkgsProblem> for Validation<A> {
 }
 
 /// A type alias representing the result of a check, either:
+///
 /// - Err(anyhow::Error): A fatal failure, typically I/O errors.
 ///   Such failures are not caused by the files in Nixpkgs.
 ///   This hints at a bug in the code or a problem with the deployment.
+///
 /// - Ok(Failure(Vec<NixpkgsProblem>)): A non-fatal validation problem with the Nixpkgs files.
 ///   Further checks can be run even with this result type.
 ///   Such problems can be fixed by changing the Nixpkgs files.
+///
 /// - Ok(Success(A)): A successful (potentially intermediate) result with an arbitrary value.
 ///   No fatal errors have occurred and no validation problems have been found with Nixpkgs.
+///
 pub type Result<A> = anyhow::Result<Validation<A>>;
 
 pub trait ResultIteratorExt<A, E>: Sized + Iterator<Item = std::result::Result<A, E>> {
@@ -43,15 +46,15 @@ impl<I, A, E> ResultIteratorExt<A, E> for I
 where
     I: Sized + Iterator<Item = std::result::Result<A, E>>,
 {
-    /// A convenience version of `collect` specialised to a vector
+    /// A convenience version of `collect` specialised to a vector.
     fn collect_vec(self) -> std::result::Result<Vec<A>, E> {
         self.collect()
     }
 }
 
 impl<A> Validation<A> {
-    /// Map a `Validation<A>` to a `Validation<B>` by applying a function to the
-    /// potentially contained value in case of success.
+    /// Map a `Validation<A>` to a `Validation<B>` by applying a function to the potentially
+    /// contained value in case of success.
     pub fn map<B>(self, f: impl FnOnce(A) -> B) -> Validation<B> {
         match self {
             Failure(err) => Failure(err),
@@ -59,8 +62,8 @@ impl<A> Validation<A> {
         }
     }
 
-    /// Map a `Validation<A>` to a `Result<B>` by applying a function `A -> Result<B>`
-    /// only if there is a `Success` value
+    /// Map a `Validation<A>` to a `Result<B>` by applying a function `A -> Result<B>` only if
+    /// there is a `Success` value.
     pub fn result_map<B>(self, f: impl FnOnce(A) -> Result<B>) -> Result<B> {
         match self {
             Failure(err) => Ok(Failure(err)),
@@ -70,8 +73,8 @@ impl<A> Validation<A> {
 }
 
 impl Validation<()> {
-    /// Combine two validations, both of which need to be successful for the return value to be successful.
-    /// The `NixpkgsProblem`s of both sides are returned concatenated.
+    /// Combine two validations, both of which need to be successful for the return value to be
+    /// successful. The `NixpkgsProblem`s of both sides are returned concatenated.
     pub fn and<A>(self, other: Validation<A>) -> Validation<A> {
         match (self, other) {
             (Success(_), Success(right_value)) => Success(right_value),
@@ -83,9 +86,12 @@ impl Validation<()> {
 }
 
 /// Combine many validations into a single one.
-/// All given validations need to be successful in order for the returned validation to be successful,
-/// in which case the returned validation value contains a `Vec` of each individual value.
-/// Otherwise the `NixpkgsProblem`s of all validations are returned concatenated.
+///
+/// All given validations need to be successful in order for the returned validation to be
+/// successful, in which case the returned validation value contains a `Vec` of each individual
+/// value.
+///
+/// Otherwise, the `NixpkgsProblem`s of all validations are returned concatenated.
 pub fn sequence<A>(check_results: impl IntoIterator<Item = Validation<A>>) -> Validation<Vec<A>> {
     let (errors, values): (Vec<Vec<NixpkgsProblem>>, Vec<A>) = check_results
         .into_iter()

--- a/tests/by-name-failure/expected
+++ b/tests/by-name-failure/expected
@@ -6,12 +6,12 @@ error:
 
        … while evaluating attribute 'ByName'
 
-         at src/eval.nix:77:7:
+         at src/eval.nix:76:7:
 
-           76|       inherit name;
-           77|       value.ByName =
+           75|       inherit name;
+           76|       value.ByName =
              |       ^
-           78|         if !pkgs ? ${name} then
+           77|         if !pkgs ? ${name} then
 
        (stack trace truncated; use '--show-trace' to show the full trace)
 


### PR DESCRIPTION
In order to prevent myself from doing these sorts of nitpicky formatting changes, here's every file (save for nixpkgs_problems.rs, since it contains so many strings!) edited to be below 100 columns.

I also added in `rustfmt` to the shell, so that I could run `cargo fmt`.