### PR TITLE
Fix warning about using old nixfmt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
     projectRootFile = ".git/config";
 
     programs.rustfmt.enable = true;
-    programs.nixfmt-rfc-style.enable = true;
+    programs.nixfmt.enable = true;
     programs.shfmt.enable = true;
     settings.formatter.shfmt.options = [ "--space-redirects" ];
   };


### PR DESCRIPTION
```
trace: warning:  nixfmt-rfc-style is now the default for the 'nixfmt' formatter.
'nixfmt-rfc-style' is deprecated and will be removed in the future.
```