### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -460,9 +460,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.69"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.10.5"
-clap = { version = "4.5.8", features = ["derive"] }
+clap = { version = "4.5.9", features = ["derive"] }
 serde_json = "1.0.120"
 tempfile = "3.10.1"
 serde = { version = "1.0.204", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre650191.ab82a9612aa4/nixexprs.tar.xz",
-      "hash": "1kbf57mm8q9j41hh6nk7f61p8zvhj8bmhp08hqld5c51fbinsca0"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre652892.aa247c0c90ec/nixexprs.tar.xz",
+      "hash": "1zp1vsbmy1yrnfglffh7jmhiq5wzgv8nc3yh76jyms072ys1l176"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "6fc8bded78715cdd43a3278a14ded226eb3a239e",
-      "url": "https://github.com/numtide/treefmt-nix/archive/6fc8bded78715cdd43a3278a14ded226eb3a239e.tar.gz",
-      "hash": "17z4n9vjjg14ky5h73iqpk3flpadcwb2h6vypizbj618vnhrghpx"
+      "revision": "b92afa1501ac73f1d745526adc4f89b527595f14",
+      "url": "https://github.com/numtide/treefmt-nix/archive/b92afa1501ac73f1d745526adc4f89b527595f14.tar.gz",
+      "hash": "0b894343f2ifnp03zvjmgd8xgy4wvhsfvz89g399c6v1pvfvp4jm"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.8   4.5.9      4.5.9  4.5.9  
   Upgrading recursive dependencies
note: pass `--verbose` to see 9 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 14 packages

```
### cargo update

```
    Updating crates.io index
    Updating syn v2.0.69 -> v2.0.71
note: pass `--verbose` to see 11 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 638 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre650191.ab82a9612aa4/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre652892.aa247c0c90ec/nixexprs.tar.xz
-    hash: 1kbf57mm8q9j41hh6nk7f61p8zvhj8bmhp08hqld5c51fbinsca0
+    hash: 1zp1vsbmy1yrnfglffh7jmhiq5wzgv8nc3yh76jyms072ys1l176
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 6fc8bded78715cdd43a3278a14ded226eb3a239e
+    revision: b92afa1501ac73f1d745526adc4f89b527595f14
-    url: https://github.com/numtide/treefmt-nix/archive/6fc8bded78715cdd43a3278a14ded226eb3a239e.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/b92afa1501ac73f1d745526adc4f89b527595f14.tar.gz
-    hash: 17z4n9vjjg14ky5h73iqpk3flpadcwb2h6vypizbj618vnhrghpx
+    hash: 0b894343f2ifnp03zvjmgd8xgy4wvhsfvz89g399c6v1pvfvp4jm
[INFO ] Update successful.
```
</details>
