### PR TITLE
Fixed Nix version and testing of multiple versions (and fix them for nixVersions.minimum)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ Integration tests are declared in [`./tests`](./tests) as subdirectories imitati
   A file containing the expected standard output.
   The default is expecting an empty standard output.
 
+  This file is matched against the error almost literally,
+  with the only exception being that the `@REDACTED@` string can match anything,
+  which is useful for non-deterministic errors.
+
 ## Automation
 
 Pinned dependencies are [regularly updated automatically](./.github/workflows/update.yml).

--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,9 @@ let
     settings.formatter.shfmt.options = [ "--space-redirects" ];
   };
 
+  # The resulting package is built to always use this Nix version, such that the result is reproducible
+  defaultNixPackage = pkgs.nix;
+
   packages = {
     build = pkgs.callPackage ./package.nix {
       inherit
@@ -54,10 +57,12 @@ let
         testNixpkgsPath
         version
         ;
+      nix = defaultNixPackage;
     };
 
     shell = pkgs.mkShell {
       env.NIX_CHECK_BY_NAME_EXPR_PATH = toString runtimeExprPath;
+      env.NIX_CHECK_BY_NAME_NIX_PACKAGE = lib.getBin defaultNixPackage;
       env.NIX_PATH = "test-nixpkgs=${toString testNixpkgsPath}:test-nixpkgs/lib=${toString nixpkgsLibPath}";
       env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
       inputsFrom = [ packages.build ];
@@ -69,6 +74,7 @@ let
         rust-analyzer
         rustfmt
         treefmtEval.config.build.wrapper
+        defaultNixPackage
       ];
     };
 

--- a/package.nix
+++ b/package.nix
@@ -2,8 +2,14 @@
   lib,
   rustPlatform,
   nix,
+  nixVersions,
   clippy,
   makeWrapper,
+
+  nixVersionsToTest ? [
+    nix
+    nixVersions.stable
+  ],
 
   nixpkgsLibPath,
   initNix,
@@ -28,15 +34,28 @@ rustPlatform.buildRustPackage {
   };
   cargoLock.lockFile = ./Cargo.lock;
   nativeBuildInputs = [
-    nix
     clippy
     makeWrapper
   ];
   env.NIX_CHECK_BY_NAME_EXPR_PATH = "${runtimeExprPath}";
   env.NIX_CHECK_BY_NAME_NIX_PACKAGE = lib.getBin nix;
   env.NIX_PATH = "test-nixpkgs=${testNixpkgsPath}:test-nixpkgs/lib=${nixpkgsLibPath}";
-  preCheck = initNix;
-  postCheck = ''
+  checkPhase = ''
+    # This path will be symlinked to the current version that is being tested
+    nixPackage=$(mktemp -d)/nix
+    # For initNix
+    export PATH=$nixPackage/bin:$PATH
+    # This is what nixpkgs-check-by-name uses
+    export NIX_CHECK_BY_NAME_NIX_PACKAGE=$nixPackage
+
+    ${lib.concatMapStringsSep "\n" (nix: ''
+      ln -s ${lib.getBin nix} "$nixPackage"
+      echo "Testing with $(nix --version)"
+      ${initNix}
+      runHook cargoCheckHook
+      rm "$nixPackage"
+    '') (lib.unique nixVersionsToTest)}
+
     # --tests or --all-targets include tests for linting
     cargo clippy --all-targets -- -D warnings
   '';

--- a/package.nix
+++ b/package.nix
@@ -9,6 +9,7 @@
   nixVersionsToTest ? [
     nix
     nixVersions.stable
+    nixVersions.minimum
   ],
 
   nixpkgsLibPath,

--- a/package.nix
+++ b/package.nix
@@ -33,6 +33,7 @@ rustPlatform.buildRustPackage {
     makeWrapper
   ];
   env.NIX_CHECK_BY_NAME_EXPR_PATH = "${runtimeExprPath}";
+  env.NIX_CHECK_BY_NAME_NIX_PACKAGE = lib.getBin nix;
   env.NIX_PATH = "test-nixpkgs=${testNixpkgsPath}:test-nixpkgs/lib=${nixpkgsLibPath}";
   preCheck = initNix;
   postCheck = ''
@@ -41,6 +42,7 @@ rustPlatform.buildRustPackage {
   '';
   postInstall = ''
     wrapProgram $out/bin/nixpkgs-check-by-name \
-      --set NIX_CHECK_BY_NAME_EXPR_PATH "$NIX_CHECK_BY_NAME_EXPR_PATH"
+      --set NIX_CHECK_BY_NAME_EXPR_PATH "$NIX_CHECK_BY_NAME_EXPR_PATH" \
+      --set NIX_CHECK_BY_NAME_NIX_PACKAGE ${lib.getBin nix}
   '';
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -125,8 +125,12 @@ pub fn check_values(
     let expr_path = std::env::var("NIX_CHECK_BY_NAME_EXPR_PATH")
         .with_context(|| "Could not get environment variable NIX_CHECK_BY_NAME_EXPR_PATH")?;
 
+    // Pinning nix in this way makes the tool more reproducible
+    let nix_package = std::env::var("NIX_CHECK_BY_NAME_NIX_PACKAGE")
+        .with_context(|| "Could not get environment variable NIX_CHECK_BY_NAME_NIX_PACKAGE")?;
+
     // With restrict-eval, only paths in NIX_PATH can be accessed. We explicitly specify them here.
-    let mut command = process::Command::new("nix-instantiate");
+    let mut command = process::Command::new(format!("{nix_package}/bin/nix-instantiate"));
     command
         // Capture stderr so that it can be printed later in case of failure
         .stderr(process::Stdio::piped())

--- a/tests/by-name-failure/expected
+++ b/tests/by-name-failure/expected
@@ -1,20 +1,4 @@
 trace: This should be on stderr!
-error:
-       … while evaluating list element at index 3
-
-       … while evaluating list element at index 1
-
-       … while evaluating attribute 'ByName'
-
-         at src/eval.nix:76:7:
-
-           75|       inherit name;
-           76|       value.ByName =
-             |       ^
-           77|         if !pkgs ? ${name} then
-
-       (stack trace truncated; use '--show-trace' to show the full trace)
-
-       error: This is an error!
+@REDACTED@error: This is an error!@REDACTED@
 - Nix evaluation failed for some package in `pkgs/by-name`, see error above
 This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.


### PR DESCRIPTION
This is a precursor to #79:
- Use a fixed Nix version instead of whatever happens to be in `PATH`, so we shouldn't ever have issues like #78 anymore
- Sets up testing for other Nix versions as part of the main build. In comparison with #79, this runs the entire test suite with multiple Nix versions, giving both more coverage while also taking much less time.
- Fixes the build for `nixVersions.minimum`, which we should switch to in the future, because it's what Nixpkgs CI should be using.

This also makes it very easy to add further Nix versions to be tested, which is what #79 can then benefit from.

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: