### PR TITLE
eval: use a work directory instead of an environment variable to control the Nix expression

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,6 @@ let
   };
   inherit (pkgs) lib;
 
-  runtimeExprPath = ./src/eval.nix;
   testNixpkgsPath = ./tests/mock-nixpkgs.nix;
   nixpkgsLibPath = nixpkgs + "/lib";
 
@@ -53,7 +52,6 @@ let
       inherit
         nixpkgsLibPath
         initNix
-        runtimeExprPath
         testNixpkgsPath
         version
         ;
@@ -61,7 +59,6 @@ let
     };
 
     shell = pkgs.mkShell {
-      env.NIX_CHECK_BY_NAME_EXPR_PATH = toString runtimeExprPath;
       env.NIX_CHECK_BY_NAME_NIX_PACKAGE = lib.getBin defaultNixPackage;
       env.NIX_PATH = "test-nixpkgs=${toString testNixpkgsPath}:test-nixpkgs/lib=${toString nixpkgsLibPath}";
       env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";

--- a/package.nix
+++ b/package.nix
@@ -14,7 +14,6 @@
 
   nixpkgsLibPath,
   initNix,
-  runtimeExprPath,
   testNixpkgsPath,
   version,
 }:
@@ -38,7 +37,6 @@ rustPlatform.buildRustPackage {
     clippy
     makeWrapper
   ];
-  env.NIX_CHECK_BY_NAME_EXPR_PATH = "${runtimeExprPath}";
   env.NIX_CHECK_BY_NAME_NIX_PACKAGE = lib.getBin nix;
   env.NIX_PATH = "test-nixpkgs=${testNixpkgsPath}:test-nixpkgs/lib=${nixpkgsLibPath}";
   checkPhase = ''
@@ -62,7 +60,6 @@ rustPlatform.buildRustPackage {
   '';
   postInstall = ''
     wrapProgram $out/bin/nixpkgs-check-by-name \
-      --set NIX_CHECK_BY_NAME_EXPR_PATH "$NIX_CHECK_BY_NAME_EXPR_PATH" \
       --set NIX_CHECK_BY_NAME_NIX_PACKAGE ${lib.getBin nix}
   '';
 }


### PR DESCRIPTION
# Motivation

This reduces the list of environment variables needed in order to use the unwrapped `nixpkgs-check-name` tool to one: `NIX_CHECK_BY_NAME_NIX_PACKAGE`. #79 now needs to use the unwrapped tool in order to control which Nix is used in an integration test, but it shouldn't have to figure this detail out.

No test used the `NIX_CHECK_BY_NAME_EXPR_PATH` to change the Nix file that was read, and it's simpler and shorter to rebuild in order to test out changes to the `src/eval.nix`.

# Things Done

- [x] Removed the Nix plumbing around `runtimeExprPath`
- [x] Removed the `NIX_CHECK_BY_NAME_EXPR_PATH` environment variable
- [x] Embedded `eval.nix` in the binary
- [x] Used a work directory instead of a temporary file 