### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
@@ -460,9 +460,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre652892.aa247c0c90ec/nixexprs.tar.xz",
-      "hash": "1zp1vsbmy1yrnfglffh7jmhiq5wzgv8nc3yh76jyms072ys1l176"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre655854.c19d62ad2265/nixexprs.tar.xz",
+      "hash": "1q27dm5xm63r6sbm9p88jznqh93sgqm8jk5njx7rd1rh4flp3f03"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "b92afa1501ac73f1d745526adc4f89b527595f14",
-      "url": "https://github.com/numtide/treefmt-nix/archive/b92afa1501ac73f1d745526adc4f89b527595f14.tar.gz",
-      "hash": "0b894343f2ifnp03zvjmgd8xgy4wvhsfvz89g399c6v1pvfvp4jm"
+      "revision": "888bfb10a9b091d9ed2f5f8064de8d488f7b7c97",
+      "url": "https://github.com/numtide/treefmt-nix/archive/888bfb10a9b091d9ed2f5f8064de8d488f7b7c97.tar.gz",
+      "hash": "0j66whp0wxw5cph7mxx3d9m9d7x0immkwdcq7aw59cqky11wpmf0"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
    Updating redox_syscall v0.5.2 -> v0.5.3
    Updating syn v2.0.71 -> v2.0.72
note: pass `--verbose` to see 11 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 642 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre652892.aa247c0c90ec/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre655854.c19d62ad2265/nixexprs.tar.xz
-    hash: 1zp1vsbmy1yrnfglffh7jmhiq5wzgv8nc3yh76jyms072ys1l176
+    hash: 1q27dm5xm63r6sbm9p88jznqh93sgqm8jk5njx7rd1rh4flp3f03
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: b92afa1501ac73f1d745526adc4f89b527595f14
+    revision: 888bfb10a9b091d9ed2f5f8064de8d488f7b7c97
-    url: https://github.com/numtide/treefmt-nix/archive/b92afa1501ac73f1d745526adc4f89b527595f14.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/888bfb10a9b091d9ed2f5f8064de8d488f7b7c97.tar.gz
-    hash: 0b894343f2ifnp03zvjmgd8xgy4wvhsfvz89g399c6v1pvfvp4jm
+    hash: 0j66whp0wxw5cph7mxx3d9m9d7x0immkwdcq7aw59cqky11wpmf0
[INFO ] Update successful.
```
</details>
