### PR TITLE
eval: remove is_test and embed mock-nixpkgs.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,9 +14,6 @@ let
   };
   inherit (pkgs) lib;
 
-  testNixpkgsPath = ./tests/mock-nixpkgs.nix;
-  nixpkgsLibPath = nixpkgs + "/lib";
-
   # Needed to make Nix evaluation work inside nix builds
   initNix = ''
     export TEST_ROOT=$(pwd)/test-tmp
@@ -49,18 +46,13 @@ let
 
   packages = {
     build = pkgs.callPackage ./package.nix {
-      inherit
-        nixpkgsLibPath
-        initNix
-        testNixpkgsPath
-        version
-        ;
+      inherit initNix version;
       nix = defaultNixPackage;
     };
 
     shell = pkgs.mkShell {
       env.NIX_CHECK_BY_NAME_NIX_PACKAGE = lib.getBin defaultNixPackage;
-      env.NIX_PATH = "test-nixpkgs=${toString testNixpkgsPath}:test-nixpkgs/lib=${toString nixpkgsLibPath}";
+      env.NIX_CHECK_BY_NAME_NIXPKGS_LIB = "${nixpkgs}/lib";
       env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
       inputsFrom = [ packages.build ];
       nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
# Motivation

Similar to #84, reducing the amount of needed machinery in Nix in favor of Rust code. In particular, remove `NIX_PATH` manipulation in Nix derivations!

# Things Done

This commit does the following things:

1. Purify the environment variables entirely when calling `nix-instantiate`. Opt in to the five environment variables needed in order to run `nix-instantiate` in the Nix sandbox.
2. Remove the hard-coded `NIX_PATH` environment variables in `default.nix` and `package.nix`. These were implicitly sent through to `nix-instantiate`, along with `-I` arguments. Now, only `-I` is used.
3. Replace the `is_test` argument with `#[cfg(test)]` applied to `mutate_nix_instatiate_arguments_based_on_cfg`.

While this is slightly more lines of code that the combination of Nix and Rust that it replaces, there is less Nix logic and more Rust logic.

Additionally, the Rust logic that is test-only is contained to `cargo check` only rather than being present in the production binary.