### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.10.5"
-clap = { version = "4.5.9", features = ["derive"] }
+clap = { version = "4.5.10", features = ["derive"] }
 serde_json = "1.0.120"
 tempfile = "3.10.1"
 serde = { version = "1.0.204", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre655854.c19d62ad2265/nixexprs.tar.xz",
-      "hash": "1q27dm5xm63r6sbm9p88jznqh93sgqm8jk5njx7rd1rh4flp3f03"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre656899.4f02464258ba/nixexprs.tar.xz",
+      "hash": "045cpsm7nxhvwdf0da7vjpaprpk0vmzsnacxx50r7hh5l26glv2i"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "888bfb10a9b091d9ed2f5f8064de8d488f7b7c97",
-      "url": "https://github.com/numtide/treefmt-nix/archive/888bfb10a9b091d9ed2f5f8064de8d488f7b7c97.tar.gz",
-      "hash": "0j66whp0wxw5cph7mxx3d9m9d7x0immkwdcq7aw59cqky11wpmf0"
+      "revision": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
+      "url": "https://github.com/numtide/treefmt-nix/archive/8db8970be1fb8be9c845af7ebec53b699fe7e009.tar.gz",
+      "hash": "0pnkr7lvd8bqzc8538qvk8rlv12f26k3814p47w5x7drp38rmyp8"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.9   4.5.10     4.5.10 4.5.10 
   Upgrading recursive dependencies
note: pass `--verbose` to see 9 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 14 packages

```
### cargo update

```
    Updating crates.io index
note: pass `--verbose` to see 11 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 644 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (82 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre655854.c19d62ad2265/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre656899.4f02464258ba/nixexprs.tar.xz
-    hash: 1q27dm5xm63r6sbm9p88jznqh93sgqm8jk5njx7rd1rh4flp3f03
+    hash: 045cpsm7nxhvwdf0da7vjpaprpk0vmzsnacxx50r7hh5l26glv2i
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 888bfb10a9b091d9ed2f5f8064de8d488f7b7c97
+    revision: 8db8970be1fb8be9c845af7ebec53b699fe7e009
-    url: https://github.com/numtide/treefmt-nix/archive/888bfb10a9b091d9ed2f5f8064de8d488f7b7c97.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/8db8970be1fb8be9c845af7ebec53b699fe7e009.tar.gz
-    hash: 0j66whp0wxw5cph7mxx3d9m9d7x0immkwdcq7aw59cqky11wpmf0
+    hash: 0pnkr7lvd8bqzc8538qvk8rlv12f26k3814p47w5x7drp38rmyp8
[INFO ] Update successful.
```
</details>
