### PR TITLE
Version 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixpkgs-check-by-name"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Haven't had a release in a while, but we need one now because we have (multiple!) fixes for https://github.com/NixOS/nixpkgs-check-by-name/issues/78 :D

The release will be created automatically when this is merged, but we don't have a way for nice changelog generation (still want to finish #46! Should be almost done really), but the main thing to know is just that #78 is fixed, which allows us to un-revert https://github.com/NixOS/nixpkgs/pull/329436 in Nixpkgs

Thanks for the contributions for this release, @philiptaron and @willbush!