### PR TITLE
workflows/after-release: Allow manually running

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -1,6 +1,7 @@
 name: After Release
 
 on:
+  workflow_dispatch: # Allows triggering manually
   release:
     types: [published]
 


### PR DESCRIPTION
For some reason it didn't trigger for the 0.1.2 release. Let's trigger it manually for now:

![image](https://github.com/user-attachments/assets/7e3670ec-1d8f-40d1-ae92-27f6c6532c98)
