### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -279,6 +279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -448,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
  "memchr",
@@ -498,12 +504,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 rnix = "0.11.0"
-regex = "1.10.5"
-clap = { version = "4.5.11", features = ["derive"] }
-serde_json = "1.0.121"
-tempfile = "3.10.1"
+regex = "1.10.6"
+clap = { version = "4.5.13", features = ["derive"] }
+serde_json = "1.0.122"
+tempfile = "3.11.0"
 serde = { version = "1.0.204", features = ["derive"] }
 anyhow = "1.0"
 lazy_static = "1.5.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre658745.038fb464fcfa/nixexprs.tar.xz",
-      "hash": "16akmwffa0fdxq1f0dqzq4ny0wfdcp8gzinm57i81x9i11kjfsi9"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre662094.f3834de3782b/nixexprs.tar.xz",
+      "hash": "08hsn6r3sslvp31j3cacsfwwc6jzml9z03w8sbbbxjly6i4ykylk"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
-      "url": "https://github.com/numtide/treefmt-nix/archive/8db8970be1fb8be9c845af7ebec53b699fe7e009.tar.gz",
-      "hash": "0pnkr7lvd8bqzc8538qvk8rlv12f26k3814p47w5x7drp38rmyp8"
+      "revision": "768acdb06968e53aa1ee8de207fd955335c754b7",
+      "url": "https://github.com/numtide/treefmt-nix/archive/768acdb06968e53aa1ee8de207fd955335c754b7.tar.gz",
+      "hash": "0p34s2mcrsy8c1270vky0m8bx4d4sz3zc7qw94jpdpws6ckvpfxs"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
regex      1.10.5  1.10.6     1.10.6  1.10.6 
clap       4.5.11  4.5.13     4.5.13  4.5.13 
serde_json 1.0.121 1.0.122    1.0.122 1.0.122
tempfile   3.10.1  3.11.0     3.11.0  3.11.0 
   Upgrading recursive dependencies
note: pass `--verbose` to see 9 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 12 packages

```
### cargo update

```
    Updating crates.io index
note: pass `--verbose` to see 13 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 645 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (86 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre658745.038fb464fcfa/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre662094.f3834de3782b/nixexprs.tar.xz
-    hash: 16akmwffa0fdxq1f0dqzq4ny0wfdcp8gzinm57i81x9i11kjfsi9
+    hash: 08hsn6r3sslvp31j3cacsfwwc6jzml9z03w8sbbbxjly6i4ykylk
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 8db8970be1fb8be9c845af7ebec53b699fe7e009
+    revision: 768acdb06968e53aa1ee8de207fd955335c754b7
-    url: https://github.com/numtide/treefmt-nix/archive/8db8970be1fb8be9c845af7ebec53b699fe7e009.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/768acdb06968e53aa1ee8de207fd955335c754b7.tar.gz
-    hash: 0pnkr7lvd8bqzc8538qvk8rlv12f26k3814p47w5x7drp38rmyp8
+    hash: 0p34s2mcrsy8c1270vky0m8bx4d4sz3zc7qw94jpdpws6ckvpfxs
[INFO ] Update successful.
```
</details>
