### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -221,9 +221,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "linux-raw-sys"
@@ -246,15 +246,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "nixpkgs-check-by-name"
@@ -390,13 +381,12 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.15.15"
+version = "0.15.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
+checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
 dependencies = [
  "countme",
  "hashbrown",
- "memoffset",
  "rustc-hash",
  "text-size",
 ]
@@ -434,18 +424,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.206"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.206"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -454,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -484,9 +474,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.10.6"
-clap = { version = "4.5.15", features = ["derive"] }
-serde_json = "1.0.124"
+clap = { version = "4.5.16", features = ["derive"] }
+serde_json = "1.0.125"
 tempfile = "3.12.0"
-serde = { version = "1.0.206", features = ["derive"] }
+serde = { version = "1.0.208", features = ["derive"] }
 anyhow = "1.0"
 lazy_static = "1.5.0"
 colored = "2.1.0"
 itertools = "0.13.0"
-rowan = "0.15.15"
+rowan = "0.15.16"
 indoc = "2.0.5"
 relative-path = "1.9.3"
 textwrap = "0.16.1"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre664329.154bcb95ad51/nixexprs.tar.xz",
-      "hash": "0mny6j9ahl87m7cv508dbll8yk29v4xha0bsdwnh1y8zkgsydgqw"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre668850.9aa35efbea27/nixexprs.tar.xz",
+      "hash": "1559wvcghhhf01dww89hdp8kqpj65m5yj7sgs09605vvp8ndzya6"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "349de7bc435bdff37785c2466f054ed1766173be",
-      "url": "https://github.com/numtide/treefmt-nix/archive/349de7bc435bdff37785c2466f054ed1766173be.tar.gz",
-      "hash": "00rl26qj3cd1336cpjdfijypi47ig7fp7a0620xq5l71x6qsyhab"
+      "revision": "1d07739554fdc4f8481068f1b11d6ab4c1a4167a",
+      "url": "https://github.com/numtide/treefmt-nix/archive/1d07739554fdc4f8481068f1b11d6ab4c1a4167a.tar.gz",
+      "hash": "05w4yxkhp93fpn911fcl4zq0rkliqcz93s1gc1k646kflggaq65f"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-check-by-name's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
clap       4.5.15  4.5.16     4.5.16  4.5.16 
serde_json 1.0.124 1.0.125    1.0.125 1.0.125
serde      1.0.206 1.0.208    1.0.208 1.0.208
rowan      0.15.15 0.15.16    0.15.16 0.15.16
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 12 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating libc v0.2.155 -> v0.2.158
    Updating syn v2.0.74 -> v2.0.75
note: pass `--verbose` to see 13 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 648 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (86 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre664329.154bcb95ad51/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre668850.9aa35efbea27/nixexprs.tar.xz
-    hash: 0mny6j9ahl87m7cv508dbll8yk29v4xha0bsdwnh1y8zkgsydgqw
+    hash: 1559wvcghhhf01dww89hdp8kqpj65m5yj7sgs09605vvp8ndzya6
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 349de7bc435bdff37785c2466f054ed1766173be
+    revision: 1d07739554fdc4f8481068f1b11d6ab4c1a4167a
-    url: https://github.com/numtide/treefmt-nix/archive/349de7bc435bdff37785c2466f054ed1766173be.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/1d07739554fdc4f8481068f1b11d6ab4c1a4167a.tar.gz
-    hash: 00rl26qj3cd1336cpjdfijypi47ig7fp7a0620xq5l71x6qsyhab
+    hash: 05w4yxkhp93fpn911fcl4zq0rkliqcz93s1gc1k646kflggaq65f
[INFO ] Update successful.
```
</details>
