### PR TITLE
fix autoPrUpdate scripts/CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -81,7 +81,11 @@ let
         updateScripts = {
           npins = pkgs.writeShellApplication {
             name = "update-npins";
-            runtimeInputs = with pkgs; [ npins ];
+            runtimeInputs = [
+              defaultNixPackage
+              pkgs.npins
+              pkgs.openssh
+            ];
             text = ''
               echo "<details><summary>npins changes</summary>"
               # Needed because GitHub's rendering of the first body line breaks down otherwise
@@ -102,6 +106,7 @@ let
               cargo-audit
               cargo-edit # provides `cargo upgrade`
               cargo-outdated
+              openssh
             ];
             text = ''
               echo "<details><summary>cargo changes</summary>"


### PR DESCRIPTION
It seems that we now need an explicit dependency on nix to get nix-prefetch-url. This causes CI to fail, both on pull requests and on scheduled jobs (e.g. https://github.com/NixOS/nixpkgs-vet/actions/runs/18845166075/job/53767161451).

It also seems that openssh is required for git to work (as is required by npins and cargo), at least locally for me. This may be due to my local configuration? Even if it is, I think there's minimal harm in adding the requirement.
