### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -75,21 +75,21 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -208,7 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,14 +219,14 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
@@ -243,15 +243,18 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -270,9 +273,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "linux-raw-sys"
@@ -282,11 +285,10 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -337,15 +339,15 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -353,15 +355,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -376,18 +378,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -400,18 +402,18 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -421,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -432,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "relative-path"
@@ -483,8 +485,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -561,9 +569,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -589,7 +597,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -611,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-linebreak"
@@ -623,9 +631,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -640,15 +648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -678,14 +677,14 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -708,19 +707,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.4"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -731,9 +730,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -743,9 +742,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -755,9 +754,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -767,9 +766,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -779,9 +778,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -791,9 +790,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -803,9 +802,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -815,9 +814,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 
 [dependencies]
 rnix = "0.12.0"
-regex = "1.11.3"
-clap = { version = "4.5.48", features = ["derive"] }
+regex = "1.12.2"
+clap = { version = "4.5.51", features = ["derive"] }
 serde_json = "1.0.145"
 tempfile = "3.23.0"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -14,7 +14,7 @@ anyhow = "1.0"
 colored = "3.0.0"
 itertools = "0.14.0"
 rowan = "0.15.17"
-indoc = "2.0.6"
+indoc = "2.0.7"
 relative-path = "2.0.1"
 textwrap = "0.16.2"
 derive-enum-from-into = "0.2.1"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-      "url": "https://github.com/nixos/nixpkgs/archive/e9f00bd893984bc8ce46c895c3bf7cac95331127.tar.gz",
-      "hash": "0s2mhbrgzxlgkg2yxb0q0hpk8lby1a7w67dxvfmaz4gsmc0bnvfj"
+      "revision": "650fadd877e41804a0b9013eb16ab4893933fd7f",
+      "url": "https://github.com/nixos/nixpkgs/archive/650fadd877e41804a0b9013eb16ab4893933fd7f.tar.gz",
+      "hash": "0ghs59bpdk79kdjhdwk1xi4bk6xv19fhvqp44hvdi1ly71h4qag1"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
-      "url": "https://github.com/numtide/treefmt-nix/archive/5eda4ee8121f97b218f7cc73f5172098d458f1d1.tar.gz",
-      "hash": "1vqns9hjhmbnhdq2xvcmdxng11jrmcn9lpk2ncfh1f969z9lj8y9"
+      "revision": "2eddae033e4e74bf581c2d1dfa101f9033dbd2dc",
+      "url": "https://github.com/numtide/treefmt-nix/archive/2eddae033e4e74bf581c2d1dfa101f9033dbd2dc.tar.gz",
+      "hash": "0xnppaig8nav7r0xviz7i87irv8bzjhhp9v080rkljkrqklvrjij"
     }
   },
   "version": 5


### PR DESCRIPTION
Running /nix/store/7dc2b9n40wacfa6bn42md2qyvpz83wh8-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name  old req compatible latest new req
====  ======= ========== ====== =======
regex 1.11.3  1.12.2     1.12.2 1.12.2 
clap  4.5.48  4.5.51     4.5.51 4.5.51 
indoc 2.0.6   2.0.7      2.0.7  2.0.7  
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.89.0 compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 14 packages

```
### cargo update

```
    Updating crates.io index
     Locking 31 packages to latest Rust 1.89.0 compatible versions
    Updating aho-corasick v1.1.3 -> v1.1.4
    Updating anstream v0.6.20 -> v0.6.21
    Updating anstyle v1.0.11 -> v1.0.13
    Updating bitflags v2.9.4 -> v2.10.0
    Updating cfg-if v1.0.3 -> v1.0.4
    Updating clap_lex v0.7.5 -> v0.7.6
    Updating getrandom v0.3.3 -> v0.3.4
    Updating is_terminal_polyfill v1.70.1 -> v1.70.2
    Updating libc v0.2.176 -> v0.2.177
    Updating lock_api v0.4.13 -> v0.4.14
    Updating once_cell_polyfill v1.70.1 -> v1.70.2
    Updating parking_lot v0.12.4 -> v0.12.5
    Updating parking_lot_core v0.9.11 -> v0.9.12
    Updating proc-macro2 v1.0.101 -> v1.0.103
    Updating quote v1.0.40 -> v1.0.41
    Updating redox_syscall v0.5.17 -> v0.5.18
    Updating regex-syntax v0.8.6 -> v0.8.8
    Updating syn v2.0.106 -> v2.0.108
    Updating unicode-ident v1.0.19 -> v1.0.22
    Updating unicode-width v0.2.1 -> v0.2.2
    Removing wasi v0.14.7+wasi-0.2.4
    Updating windows-link v0.2.0 -> v0.2.1
    Updating windows-sys v0.61.1 -> v0.61.2
    Updating windows-targets v0.53.4 -> v0.53.5
    Updating windows_aarch64_gnullvm v0.53.0 -> v0.53.1
    Updating windows_aarch64_msvc v0.53.0 -> v0.53.1
    Updating windows_i686_gnu v0.53.0 -> v0.53.1
    Updating windows_i686_gnullvm v0.53.0 -> v0.53.1
    Updating windows_i686_msvc v0.53.0 -> v0.53.1
    Updating windows_x86_64_gnu v0.53.0 -> v0.53.1
    Updating windows_x86_64_gnullvm v0.53.0 -> v0.53.1
    Updating windows_x86_64_msvc v0.53.0 -> v0.53.1
note: pass `--verbose` to see 1 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 862 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (100 crate dependencies)

```
</details>
Running /nix/store/wi1x79a44k2pr766qr9cjzfkb2xkhx37-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.72.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.72.0
    cli | 2025/11/03 14:50:46 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2025/11/03 14:50:47 proxy starting, commit: 32f72c93e3b014db177b94dcad54e96d6e241a4a
  proxy | 2025/11/03 14:50:47 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | 2025/11/03 14:50:49 INFO Starting job processing
updater | 2025/11/03 14:50:49 INFO Job definition: {"job":{"package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2025/11/03 14:50:50 INFO Base commit SHA: 0397666018f22ad899b7161746cbd02930d0de4e
updater | 2025/11/03 14:50:50 INFO Finished job processing
updater | 2025/11/03 14:50:51 INFO Starting job processing
  proxy | 2025/11/03 14:50:51 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:51 [002] * authenticating git server request (host: github.com)
  proxy | 2025/11/03 14:50:52 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [004] * authenticating git server request (host: github.com)
  proxy | 2025/11/03 14:50:52 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:52 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [008] * authenticating git server request (host: github.com)
  proxy | 2025/11/03 14:50:52 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:52 [010] * authenticating git server request (host: github.com)
  proxy | 2025/11/03 14:50:52 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [017] POST http://host.docker.internal:41975/update_jobs/cli/update_dependency_list
  proxy | 2025/11/03 14:50:53 [017] 200 http://host.docker.internal:41975/update_jobs/cli/update_dependency_list
  proxy | 2025/11/03 14:50:53 [018] POST http://host.docker.internal:41975/update_jobs/cli/increment_metric
  proxy | 2025/11/03 14:50:53 [018] 200 http://host.docker.internal:41975/update_jobs/cli/increment_metric
updater | 2025/11/03 14:50:53 INFO Starting grouped update job for not/used
updater | 2025/11/03 14:50:53 INFO Found 1 group(s).
updater | 2025/11/03 14:50:53 INFO Starting update group for 'actions'
updater | 2025/11/03 14:50:53 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2025/11/03 14:50:53 INFO Job specified dependencies: 
updater | 2025/11/03 14:50:53 INFO Updating the / directory.
  proxy | 2025/11/03 14:50:53 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:53 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:53 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:54 INFO Checking if actions/checkout 5 needs updating
  proxy | 2025/11/03 14:50:54 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:54 INFO Available release version/ref is 5
updater | 2025/11/03 14:50:54 INFO Latest version is 5
updater | 2025/11/03 14:50:54 INFO Adding dependencies as handled: (actions/checkout).
updater | 2025/11/03 14:50:54 INFO No update needed for actions/checkout 5
  proxy | 2025/11/03 14:50:54 [038] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [038] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [040] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [040] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [042] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [042] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [044] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [044] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [046] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [046] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:54 [048] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:54 [048] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [050] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [050] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [052] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [052] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:55 INFO Checking if peter-evans/create-pull-request 7 needs updating
  proxy | 2025/11/03 14:50:55 [054] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [054] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:55 INFO Available release version/ref is 7
updater | 2025/11/03 14:50:55 INFO Latest version is 7
updater | 2025/11/03 14:50:55 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
updater | 2025/11/03 14:50:55 INFO No update needed for peter-evans/create-pull-request 7
  proxy | 2025/11/03 14:50:55 [056] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [056] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [058] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [058] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [060] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [060] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [062] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [062] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [064] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [064] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:55 [066] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:55 [066] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [068] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [068] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [070] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [070] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:56 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2025/11/03 14:50:56 [072] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [072] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:56 INFO Available release version/ref is 31
updater | 2025/11/03 14:50:56 INFO Latest version is 31
updater | 2025/11/03 14:50:56 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2025/11/03 14:50:56 INFO No update needed for cachix/install-nix-action 31
  proxy | 2025/11/03 14:50:56 [074] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [074] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [076] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [076] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [078] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [078] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [080] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [080] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [082] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [082] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:56 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:56 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:57 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:57 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/03 14:50:57 [088] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:57 [088] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:57 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2025/11/03 14:50:57 [090] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/03 14:50:57 [090] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/03 14:50:57 INFO Available release version/ref is 1
updater | 2025/11/03 14:50:57 INFO Latest version is 1
updater | 2025/11/03 14:50:57 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2025/11/03 14:50:57 INFO No update needed for serokell/xrefcheck-action 1
updater | 2025/11/03 14:50:57 INFO Nothing to update for Dependency Group: 'actions'
updater | 2025/11/03 14:50:57 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2025/11/03 14:50:57 [091] PATCH http://host.docker.internal:41975/update_jobs/cli/mark_as_processed
  proxy | 2025/11/03 14:50:57 [091] 200 http://host.docker.internal:41975/update_jobs/cli/mark_as_processed
updater | 2025/11/03 14:50:57 INFO Finished job processing
  proxy | 2025/11/03 14:50:57 Skipping sending metrics because api endpoint is empty
  proxy | 2025/11/03 14:50:57 40/44 calls cached (90%)
</details>
Running /nix/store/jxs4zq8pkf6r852jciqp8ipnbpgsm0ap-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 5eda4ee8121f97b218f7cc73f5172098d458f1d1
+    revision: 2eddae033e4e74bf581c2d1dfa101f9033dbd2dc
-    url: https://github.com/numtide/treefmt-nix/archive/5eda4ee8121f97b218f7cc73f5172098d458f1d1.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/2eddae033e4e74bf581c2d1dfa101f9033dbd2dc.tar.gz
-    hash: 1vqns9hjhmbnhdq2xvcmdxng11jrmcn9lpk2ncfh1f969z9lj8y9
+    hash: 0xnppaig8nav7r0xviz7i87irv8bzjhhp9v080rkljkrqklvrjij
[nixpkgs] Changes:
-    revision: e9f00bd893984bc8ce46c895c3bf7cac95331127
+    revision: 650fadd877e41804a0b9013eb16ab4893933fd7f
-    url: https://github.com/nixos/nixpkgs/archive/e9f00bd893984bc8ce46c895c3bf7cac95331127.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/650fadd877e41804a0b9013eb16ab4893933fd7f.tar.gz
-    hash: 0s2mhbrgzxlgkg2yxb0q0hpk8lby1a7w67dxvfmaz4gsmc0bnvfj
+    hash: 0ghs59bpdk79kdjhdwk1xi4bk6xv19fhvqp44hvdi1ly71h4qag1
[INFO ] Update successful.
```
</details>
