### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,22 +43,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -668,16 +668,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -695,31 +686,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -729,22 +703,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -753,22 +715,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -777,22 +727,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -801,22 +739,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "b7af8dcd4a8e0282351a1d771b7e432157118435",
-      "url": "https://github.com/nixos/nixpkgs/archive/b7af8dcd4a8e0282351a1d771b7e432157118435.tar.gz",
-      "hash": "0k9cw9l3bsgk56mcl6fk9chxbwsla4262s33sdn3agdcsbk5z1iz"
+      "revision": "3099c858a7b0e99f6f617f08286a796a635fac43",
+      "url": "https://github.com/nixos/nixpkgs/archive/3099c858a7b0e99f6f617f08286a796a635fac43.tar.gz",
+      "hash": "17rjs3kya1n9sr21akkyqfwngq9ylgwl4ihrn1shyaz9z1zfmhi5"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "97a30861b13c3731a84e09405414398fbf3e109f",
-      "url": "https://github.com/numtide/treefmt-nix/archive/97a30861b13c3731a84e09405414398fbf3e109f.tar.gz",
-      "hash": "0j2cg7x4g8z9hgxj4bf7fy6r8xq5ahqpl6rxqm7p78ayhsz5ypk8"
+      "revision": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
+      "url": "https://github.com/numtide/treefmt-nix/archive/5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4.tar.gz",
+      "hash": "0cr6aj9bk7n3y09lwmfjr7xg1f069332xf4q99z3kj1c1mp0wl82"
     }
   },
   "version": 5


### PR DESCRIPTION
Running /nix/store/ar95wfb13w8w417sa2krm3ylmh6005yx-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 17 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest Rust 1.89.0 compatible versions
    Updating anstyle-query v1.1.4 -> v1.1.5
    Updating anstyle-wincon v3.0.10 -> v3.0.11
    Removing windows-sys v0.60.2
    Removing windows-targets v0.53.5
    Removing windows_aarch64_gnullvm v0.53.1
    Removing windows_aarch64_msvc v0.53.1
    Removing windows_i686_gnu v0.53.1
    Removing windows_i686_gnullvm v0.53.1
    Removing windows_i686_msvc v0.53.1
    Removing windows_x86_64_gnu v0.53.1
    Removing windows_x86_64_gnullvm v0.53.1
    Removing windows_x86_64_msvc v0.53.1
note: pass `--verbose` to see 1 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 867 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (90 crate dependencies)

```
</details>
Running /nix/store/6nmq1m03kckpzfqmkdsf8lihb00kyq4h-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.78.1
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.78.1
    cli | 2025/11/17 14:51:31 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2025/11/17 14:51:31 proxy starting, commit: 331798d36c228432c0eccecfb1912e45eaaf66d9
  proxy | 2025/11/17 14:51:31 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2025/11/17 14:51:34 INFO Starting job processing
updater | 2025/11/17 14:51:34 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2025/11/17 14:51:34 INFO Base commit SHA: 8ac98be2fa6b00f93881d65acad9951d23552df7
updater | 2025/11/17 14:51:34 INFO Finished job processing
updater | 2025/11/17 14:51:34 INFO Starting job processing
  proxy | 2025/11/17 14:51:34 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:34 [002] * authenticating git server request (host: github.com)
  proxy | 2025/11/17 14:51:34 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:34 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:34 [004] * authenticating git server request (host: github.com)
  proxy | 2025/11/17 14:51:34 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:35 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [008] * authenticating git server request (host: github.com)
  proxy | 2025/11/17 14:51:35 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [010] * authenticating git server request (host: github.com)
  proxy | 2025/11/17 14:51:35 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:35 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:35 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:35 [017] POST http://host.docker.internal:43517/update_jobs/cli/update_dependency_list
  proxy | 2025/11/17 14:51:35 [017] 200 http://host.docker.internal:43517/update_jobs/cli/update_dependency_list
  proxy | 2025/11/17 14:51:35 [018] POST http://host.docker.internal:43517/update_jobs/cli/increment_metric
  proxy | 2025/11/17 14:51:35 [018] 200 http://host.docker.internal:43517/update_jobs/cli/increment_metric
updater | 2025/11/17 14:51:35 INFO Starting grouped update job for not/used
updater | 2025/11/17 14:51:35 INFO Found 1 group(s).
updater | 2025/11/17 14:51:35 INFO Starting update group for 'actions'
updater | 2025/11/17 14:51:35 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2025/11/17 14:51:35 INFO Job specified dependencies: 
updater | 2025/11/17 14:51:35 INFO Updating the / directory.
  proxy | 2025/11/17 14:51:35 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:35 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:36 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:36 INFO Checking if actions/checkout 5 needs updating
  proxy | 2025/11/17 14:51:36 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:36 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:36 INFO Available release version/ref is 5
updater | 2025/11/17 14:51:36 INFO Latest version is 5
updater | 2025/11/17 14:51:36 INFO Adding dependencies as handled: (actions/checkout).
updater | 2025/11/17 14:51:36 INFO No update needed for actions/checkout 5
  proxy | 2025/11/17 14:51:37 [038] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [038] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [040] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [040] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [042] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [042] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [044] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [044] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [046] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [046] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [048] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [048] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [050] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [050] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:37 [052] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [052] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:37 INFO Checking if peter-evans/create-pull-request 7 needs updating
  proxy | 2025/11/17 14:51:37 [054] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:37 [054] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:38 INFO Available release version/ref is 7
updater | 2025/11/17 14:51:38 INFO Latest version is 7
updater | 2025/11/17 14:51:38 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
updater | 2025/11/17 14:51:38 INFO No update needed for peter-evans/create-pull-request 7
  proxy | 2025/11/17 14:51:38 [056] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [056] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [058] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [058] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [060] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [060] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [062] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [062] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [064] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [064] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [066] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [066] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [068] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [068] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:38 [070] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [070] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:38 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2025/11/17 14:51:38 [072] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:38 [072] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:38 INFO Available release version/ref is 31
updater | 2025/11/17 14:51:38 INFO Latest version is 31
updater | 2025/11/17 14:51:38 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2025/11/17 14:51:38 INFO No update needed for cachix/install-nix-action 31
  proxy | 2025/11/17 14:51:39 [074] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [074] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [076] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [076] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [078] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [078] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [080] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [080] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [082] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [082] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/11/17 14:51:39 [088] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [088] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:39 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2025/11/17 14:51:39 [090] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/11/17 14:51:39 [090] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/11/17 14:51:39 INFO Available release version/ref is 1
updater | 2025/11/17 14:51:39 INFO Latest version is 1
updater | 2025/11/17 14:51:39 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2025/11/17 14:51:39 INFO No update needed for serokell/xrefcheck-action 1
updater | 2025/11/17 14:51:39 INFO Nothing to update for Dependency Group: 'actions'
updater | 2025/11/17 14:51:39 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2025/11/17 14:51:39 [091] PATCH http://host.docker.internal:43517/update_jobs/cli/mark_as_processed
  proxy | 2025/11/17 14:51:39 [091] 200 http://host.docker.internal:43517/update_jobs/cli/mark_as_processed
updater | 2025/11/17 14:51:39 INFO Finished job processing
  proxy | 2025/11/17 14:51:40 Skipping sending metrics because api endpoint is empty
  proxy | 2025/11/17 14:51:40 40/44 calls cached (90%)
</details>
Running /nix/store/9aivwm38x5kv692xrl56zfz9xcd6fcgs-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 97a30861b13c3731a84e09405414398fbf3e109f
+    revision: 5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4
-    url: https://github.com/numtide/treefmt-nix/archive/97a30861b13c3731a84e09405414398fbf3e109f.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4.tar.gz
-    hash: 0j2cg7x4g8z9hgxj4bf7fy6r8xq5ahqpl6rxqm7p78ayhsz5ypk8
+    hash: 0cr6aj9bk7n3y09lwmfjr7xg1f069332xf4q99z3kj1c1mp0wl82
[nixpkgs] Changes:
-    revision: b7af8dcd4a8e0282351a1d771b7e432157118435
+    revision: 3099c858a7b0e99f6f617f08286a796a635fac43
-    url: https://github.com/nixos/nixpkgs/archive/b7af8dcd4a8e0282351a1d771b7e432157118435.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/3099c858a7b0e99f6f617f08286a796a635fac43.tar.gz
-    hash: 0k9cw9l3bsgk56mcl6fk9chxbwsla4262s33sdn3agdcsbk5z1iz
+    hash: 17rjs3kya1n9sr21akkyqfwngq9ylgwl4ihrn1shyaz9z1zfmhi5
[INFO ] Update successful.
```
</details>
