### PR TITLE
Automated update

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -9,7 +9,7 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: NixOS/nixpkgs
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: cachix/install-nix-action@v31
         with:
@@ -43,7 +43,7 @@ jobs:
   xrefcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # While this has a Nix build available, it needs to evaluate and build so much
       # that I don't think it's worth adding it to the nix-build.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           path: repo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -141,6 +141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,21 +179,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -273,9 +284,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "linux-raw-sys"
@@ -476,6 +487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +525,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -569,9 +595,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -628,6 +654,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 rnix = "0.12.0"
 regex = "1.12.2"
-clap = { version = "4.5.51", features = ["derive"] }
+clap = { version = "4.5.53", features = ["derive"] }
 serde_json = "1.0.145"
 tempfile = "3.23.0"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -19,7 +19,7 @@ relative-path = "2.0.1"
 textwrap = "0.16.2"
 derive-enum-from-into = "0.2.1"
 derive-new = "0.7.0"
-derive_more = { version = "2.0.1", features = ["display"] }
+derive_more = { version = "2.1.0", features = ["display"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "3099c858a7b0e99f6f617f08286a796a635fac43",
-      "url": "https://github.com/nixos/nixpkgs/archive/3099c858a7b0e99f6f617f08286a796a635fac43.tar.gz",
-      "hash": "17rjs3kya1n9sr21akkyqfwngq9ylgwl4ihrn1shyaz9z1zfmhi5"
+      "revision": "96ca3529c27caa2ba3e8c17327ec551193cb12dd",
+      "url": "https://github.com/nixos/nixpkgs/archive/96ca3529c27caa2ba3e8c17327ec551193cb12dd.tar.gz",
+      "hash": "0df8d2x0sxkcf13863qssxlp67gcbi29dmgcb78h337n99l47qf6"
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/3f2hh3yph54sr9q07vhzjxrbd37swbb1-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name        old req compatible latest new req
====        ======= ========== ====== =======
clap        4.5.51  4.5.53     4.5.53 4.5.53 
derive_more 2.0.1   2.1.0      2.1.0  2.1.0  
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.90.0 compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest Rust 1.90.0 compatible versions
    Updating libc v0.2.177 -> v0.2.178
    Updating syn v2.0.110 -> v2.0.111
note: pass `--verbose` to see 1 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 884 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (94 crate dependencies)

```
</details>
Running /nix/store/p991x7x055wn846fsip6kivr4b2hazsp-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.78.1
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.78.1
    cli | 2025/12/08 14:52:07 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2025/12/08 14:52:07 proxy starting, commit: 331798d36c228432c0eccecfb1912e45eaaf66d9
  proxy | 2025/12/08 14:52:07 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2025/12/08 14:52:09 INFO Starting job processing
updater | 2025/12/08 14:52:09 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2025/12/08 14:52:09 INFO Base commit SHA: 4232c10ace71ff40ebc3cf0039cb0bf4a222f536
updater | 2025/12/08 14:52:09 INFO Finished job processing
updater | 2025/12/08 14:52:09 INFO Starting job processing
  proxy | 2025/12/08 14:52:09 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:09 [002] * authenticating git server request (host: github.com)
  proxy | 2025/12/08 14:52:10 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [004] * authenticating git server request (host: github.com)
  proxy | 2025/12/08 14:52:10 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:10 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [008] * authenticating git server request (host: github.com)
  proxy | 2025/12/08 14:52:10 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [010] * authenticating git server request (host: github.com)
  proxy | 2025/12/08 14:52:10 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:10 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:10 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [017] POST http://host.docker.internal:43477/update_jobs/cli/update_dependency_list
  proxy | 2025/12/08 14:52:11 [017] 200 http://host.docker.internal:43477/update_jobs/cli/update_dependency_list
  proxy | 2025/12/08 14:52:11 [018] POST http://host.docker.internal:43477/update_jobs/cli/increment_metric
  proxy | 2025/12/08 14:52:11 [018] 200 http://host.docker.internal:43477/update_jobs/cli/increment_metric
updater | 2025/12/08 14:52:11 INFO Starting grouped update job for not/used
updater | 2025/12/08 14:52:11 INFO Found 1 group(s).
updater | 2025/12/08 14:52:11 INFO Starting update group for 'actions'
updater | 2025/12/08 14:52:11 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2025/12/08 14:52:11 INFO Job specified dependencies: 
updater | 2025/12/08 14:52:11 INFO Updating the / directory.
  proxy | 2025/12/08 14:52:11 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:11 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:11 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:12 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:12 INFO Checking if actions/checkout 5 needs updating
  proxy | 2025/12/08 14:52:12 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:12 INFO Available release version/ref is 6
updater | 2025/12/08 14:52:12 INFO Latest version is 6
updater | 2025/12/08 14:52:12 INFO Adding dependencies as handled: (actions/checkout).
  proxy | 2025/12/08 14:52:12 [038] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [038] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:12 [040] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [040] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:12 [042] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [042] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:12 [044] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [044] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:12 [046] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [046] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:12 [048] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [048] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:12 INFO Requirements to unlock own
updater | 2025/12/08 14:52:12 INFO Requirements update strategy 
  proxy | 2025/12/08 14:52:12 [050] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:12 [050] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [052] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [052] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [054] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [054] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [056] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [056] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [058] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [058] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [060] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [060] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [062] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [062] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [064] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [064] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [066] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [066] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:13 [068] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:13 [068] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [070] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [070] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [072] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [072] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:14 INFO Creating dependency change for actions/checkout (6) in group actions
updater | 2025/12/08 14:52:14 INFO Updating actions/checkout from 5 to 6
  proxy | 2025/12/08 14:52:14 [074] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [074] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [076] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [076] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [078] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [078] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [080] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [080] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [082] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [082] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:14 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:14 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:15 [088] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [088] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:15 INFO Checking if peter-evans/create-pull-request 7 needs updating
  proxy | 2025/12/08 14:52:15 [090] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [090] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:15 INFO Available release version/ref is 7
updater | 2025/12/08 14:52:15 INFO Latest version is 7
updater | 2025/12/08 14:52:15 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
updater | 2025/12/08 14:52:15 INFO No update needed for peter-evans/create-pull-request 7
  proxy | 2025/12/08 14:52:15 [092] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [092] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:15 [094] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [094] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:15 [096] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [096] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:15 [098] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [098] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:15 [100] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [100] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:15 [102] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:15 [102] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [104] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [104] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [106] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [106] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:16 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2025/12/08 14:52:16 [108] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [108] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:16 INFO Available release version/ref is 31
updater | 2025/12/08 14:52:16 INFO Latest version is 31
updater | 2025/12/08 14:52:16 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2025/12/08 14:52:16 INFO No update needed for cachix/install-nix-action 31
  proxy | 2025/12/08 14:52:16 [110] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [110] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [112] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [112] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [114] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [114] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [116] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [116] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [118] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [118] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [120] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [120] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:16 [122] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:16 [122] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/08 14:52:17 [124] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:17 [124] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:17 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2025/12/08 14:52:17 [126] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/08 14:52:17 [126] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/08 14:52:17 INFO Available release version/ref is 1
updater | 2025/12/08 14:52:17 INFO Latest version is 1
updater | 2025/12/08 14:52:17 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2025/12/08 14:52:17 INFO No update needed for serokell/xrefcheck-action 1
updater | 2025/12/08 14:52:17 INFO Creating a pull request for 'actions'
  proxy | 2025/12/08 14:52:17 [128] GET https://api.github.com:443/repos/not/used/commits?per_page=100
  proxy | 2025/12/08 14:52:17 [128] * authenticating github api request with token for api.github.com
  proxy | 2025/12/08 14:52:17 [128] 404 https://api.github.com:443/repos/not/used/commits?per_page=100
  proxy | 2025/12/08 14:52:17 [128] * auth'd github api request failed authentication, retrying with alternate provided auth
  proxy | 2025/12/08 14:52:17 [128] * re-auth'd request returned 404, ignoring response
  proxy | 2025/12/08 14:52:17 [130] GET https://api.github.com:443/repos/actions/checkout/releases?per_page=100
  proxy | 2025/12/08 14:52:17 [130] * authenticating github api request with token for api.github.com
  proxy | 2025/12/08 14:52:17 [130] 200 https://api.github.com:443/repos/actions/checkout/releases?per_page=100
  proxy | 2025/12/08 14:52:17 [132] GET https://api.github.com:443/repos/actions/checkout/contents/
  proxy | 2025/12/08 14:52:17 [132] * authenticating github api request with token for api.github.com
  proxy | 2025/12/08 14:52:18 [132] 200 https://api.github.com:443/repos/actions/checkout/contents/
  proxy | 2025/12/08 14:52:18 [134] GET https://api.github.com:443/repos/actions/checkout/contents/CHANGELOG.md?ref=main
  proxy | 2025/12/08 14:52:18 [134] * authenticating github api request with token for api.github.com
  proxy | 2025/12/08 14:52:18 [134] 200 https://api.github.com:443/repos/actions/checkout/contents/CHANGELOG.md?ref=main
  proxy | 2025/12/08 14:52:18 [136] GET https://api.github.com:443/repos/actions/checkout/commits?sha=v5
  proxy | 2025/12/08 14:52:18 [136] * authenticating github api request with token for api.github.com
  proxy | 2025/12/08 14:52:18 [136] 200 https://api.github.com:443/repos/actions/checkout/commits?sha=v5
  proxy | 2025/12/08 14:52:18 [138] GET https://api.github.com:443/repos/actions/checkout/commits?sha=v6
  proxy | 2025/12/08 14:52:18 [138] * authenticating github api request with token for api.github.com
  proxy | 2025/12/08 14:52:18 [138] 200 https://api.github.com:443/repos/actions/checkout/commits?sha=v6
  proxy | 2025/12/08 14:52:18 [140] GET https://api.github.com:443/repos/actions/checkout/commits?sha=v5
  proxy | 2025/12/08 14:52:18 [140] 200 https://api.github.com:443/repos/actions/checkout/commits?sha=v5 (cached)
  proxy | 2025/12/08 14:52:18 [142] GET https://api.github.com:443/repos/actions/checkout/commits?sha=v6
  proxy | 2025/12/08 14:52:18 [142] 200 https://api.github.com:443/repos/actions/checkout/commits?sha=v6 (cached)
  proxy | 2025/12/08 14:52:18 [144] GET https://api.github.com:443/repos/actions/checkout/commits?sha=v5
  proxy | 2025/12/08 14:52:18 [144] 200 https://api.github.com:443/repos/actions/checkout/commits?sha=v5 (cached)
  proxy | 2025/12/08 14:52:18 [146] GET https://api.github.com:443/repos/actions/checkout/commits?sha=v6
  proxy | 2025/12/08 14:52:18 [146] 200 https://api.github.com:443/repos/actions/checkout/commits?sha=v6 (cached)
  proxy | 2025/12/08 14:52:18 [147] POST http://host.docker.internal:43477/update_jobs/cli/create_pull_request
  proxy | 2025/12/08 14:52:18 [147] 200 http://host.docker.internal:43477/update_jobs/cli/create_pull_request
updater | 2025/12/08 14:52:18 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2025/12/08 14:52:18 [148] PATCH http://host.docker.internal:43477/update_jobs/cli/mark_as_processed
  proxy | 2025/12/08 14:52:18 [148] 200 http://host.docker.internal:43477/update_jobs/cli/mark_as_processed
updater | 2025/12/08 14:52:18 INFO Finished job processing
updater | 2025/12/08 14:52:18 INFO Results:
updater | +--------------------------------------------+
updater | |    Changes to Dependabot Pull Requests     |
updater | +---------+----------------------------------+
updater | | created | actions/checkout ( from 5 to 6 ) |
updater | +---------+----------------------------------+
  proxy | 2025/12/08 14:52:19 62/72 calls cached (86%)
  proxy | 2025/12/08 14:52:19 Skipping sending metrics because api endpoint is empty
Bumps the actions group with 1 update: [actions/checkout](https://github.com/actions/checkout).

Updates `actions/checkout` from 5 to 6
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/checkout/releases">actions/checkout's releases</a>.</em></p>
<blockquote>
<h2>v6.0.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
<li>v6-beta by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2298">actions/checkout#2298</a></li>
<li>update readme/changelog for v6 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2311">actions/checkout#2311</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v5.0.0...v6.0.0">https://github.com/actions/checkout/compare/v5.0.0...v6.0.0</a></p>
<h2>v6-beta</h2>
<h2>What's Changed</h2>
<p>Updated persist-credentials to store the credentials under <code>$RUNNER_TEMP</code> instead of directly in the local git config.</p>
<p>This requires a minimum Actions Runner version of <a href="https://github.com/actions/runner/releases/tag/v2.329.0">v2.329.0</a> to access the persisted credentials for <a href="https://docs.github.com/en/actions/tutorials/use-containerized-services/create-a-docker-container-action">Docker container action</a> scenarios.</p>
<h2>v5.0.1</h2>
<h2>What's Changed</h2>
<ul>
<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v5...v5.0.1">https://github.com/actions/checkout/compare/v5...v5.0.1</a></p>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/actions/checkout/blob/main/CHANGELOG.md">actions/checkout's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>v6.0.0</h2>
<ul>
<li>Persist creds to a separate file by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2286">actions/checkout#2286</a></li>
<li>Update README to include Node.js 24 support details and requirements by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2248">actions/checkout#2248</a></li>
</ul>
<h2>v5.0.1</h2>
<ul>
<li>Port v6 cleanup to v5 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2301">actions/checkout#2301</a></li>
</ul>
<h2>v5.0.0</h2>
<ul>
<li>Update actions checkout to use node 24 by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2226">actions/checkout#2226</a></li>
</ul>
<h2>v4.3.1</h2>
<ul>
<li>Port v6 cleanup to v4 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2305">actions/checkout#2305</a></li>
</ul>
<h2>v4.3.0</h2>
<ul>
<li>docs: update README.md by <a href="https://github.com/motss"><code>@​motss</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1971">actions/checkout#1971</a></li>
<li>Add internal repos for checking out multiple repositories by <a href="https://github.com/mouismail"><code>@​mouismail</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1977">actions/checkout#1977</a></li>
<li>Documentation update - add recommended permissions to Readme by <a href="https://github.com/benwells"><code>@​benwells</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2043">actions/checkout#2043</a></li>
<li>Adjust positioning of user email note and permissions heading by <a href="https://github.com/joshmgross"><code>@​joshmgross</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2044">actions/checkout#2044</a></li>
<li>Update README.md by <a href="https://github.com/nebuk89"><code>@​nebuk89</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2194">actions/checkout#2194</a></li>
<li>Update CODEOWNERS for actions by <a href="https://github.com/TingluoHuang"><code>@​TingluoHuang</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2224">actions/checkout#2224</a></li>
<li>Update package dependencies by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2236">actions/checkout#2236</a></li>
</ul>
<h2>v4.2.2</h2>
<ul>
<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
</ul>
<h2>v4.2.1</h2>
<ul>
<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
</ul>
<h2>v4.2.0</h2>
<ul>
<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@​lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
<li>Dependency updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>- <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a>, <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
</ul>
<h2>v4.1.7</h2>
<ul>
<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
<li>Pin actions/checkout's own workflows to a known, good, stable version. by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1776">actions/checkout#1776</a></li>
</ul>
<h2>v4.1.6</h2>
<ul>
<li>Check platform to set archive extension appropriately by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1732">actions/checkout#1732</a></li>
</ul>
<h2>v4.1.5</h2>
<ul>
<li>Update NPM dependencies by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1703">actions/checkout#1703</a></li>
<li>Bump github/codeql-action from 2 to 3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1694">actions/checkout#1694</a></li>
<li>Bump actions/setup-node from 1 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1696">actions/checkout#1696</a></li>
<li>Bump actions/upload-artifact from 2 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1695">actions/checkout#1695</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8"><code>8e8c483</code></a> Clarify v6 README (<a href="https://redirect.github.com/actions/checkout/issues/2328">#2328</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/033fa0dc0b82693d8986f1016a0ec2c5e7d9cbb1"><code>033fa0d</code></a> Add worktree support for persist-credentials includeIf (<a href="https://redirect.github.com/actions/checkout/issues/2327">#2327</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5"><code>c2d88d3</code></a> Update all references from v5 and v4 to v6 (<a href="https://redirect.github.com/actions/checkout/issues/2314">#2314</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/1af3b93b6815bc44a9784bd300feb67ff0d1eeb3"><code>1af3b93</code></a> update readme/changelog for v6 (<a href="https://redirect.github.com/actions/checkout/issues/2311">#2311</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/71cf2267d89c5cb81562390fa70a37fa40b1305e"><code>71cf226</code></a> v6-beta (<a href="https://redirect.github.com/actions/checkout/issues/2298">#2298</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/069c6959146423d11cd0184e6accf28f9d45f06e"><code>069c695</code></a> Persist creds to a separate file (<a href="https://redirect.github.com/actions/checkout/issues/2286">#2286</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493"><code>ff7abcd</code></a> Update README to include Node.js 24 support details and requirements (<a href="https://redirect.github.com/actions/checkout/issues/2248">#2248</a>)</li>
<li>See full diff in <a href="https://github.com/actions/checkout/compare/v5...v6">compare view</a></li>
</ul>
</details>
<br />

</details>
Running /nix/store/fir7bczrji5zfmdwmv3l9b7nnzqpjlgb-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    revision: 3099c858a7b0e99f6f617f08286a796a635fac43
+    revision: 96ca3529c27caa2ba3e8c17327ec551193cb12dd
-    url: https://github.com/nixos/nixpkgs/archive/3099c858a7b0e99f6f617f08286a796a635fac43.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/96ca3529c27caa2ba3e8c17327ec551193cb12dd.tar.gz
-    hash: 17rjs3kya1n9sr21akkyqfwngq9ylgwl4ihrn1shyaz9z1zfmhi5
+    hash: 0df8d2x0sxkcf13863qssxlp67gcbi29dmgcb78h337n99l47qf6
[INFO ] Update successful.
```
</details>
