### PR TITLE
Automated update

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -25,7 +25,7 @@ jobs:
           echo "after=$(<pkgs/test/check-by-name/pinned-version.txt)" >> $GITHUB_ENV
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           # To trigger CI for automated PRs, we use a separate machine account
           # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ github.event_name != 'pull_request' }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           # To trigger CI for automated PRs, we use a separate machine account
           # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "96ca3529c27caa2ba3e8c17327ec551193cb12dd",
-      "url": "https://github.com/nixos/nixpkgs/archive/96ca3529c27caa2ba3e8c17327ec551193cb12dd.tar.gz",
-      "hash": "0df8d2x0sxkcf13863qssxlp67gcbi29dmgcb78h337n99l47qf6"
+      "revision": "88b3c158c151e06b34b978b59eb8196df370ef83",
+      "url": "https://github.com/nixos/nixpkgs/archive/88b3c158c151e06b34b978b59eb8196df370ef83.tar.gz",
+      "hash": "0gygfkb5gxsgbhrcswb7hkz8xvvsll98snsj3rlb01q97258ndra"
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/aacknjpk64xf914prcb9fyz45wj6lw18-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 17 packages

```
### cargo update

```
    Updating crates.io index
     Locking 0 packages to latest Rust 1.91.1 compatible versions
note: pass `--verbose` to see 1 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 885 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (94 crate dependencies)

```
</details>
Running /nix/store/ipv2i4qhlxvs0i8gzdh1vq2xmamhpmql-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.79.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.79.0
    cli | 2025/12/15 14:55:03 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2025/12/15 14:55:04 proxy starting, commit: b221ac2642bfce9fbec74e164aa807c6b4a2c945
  proxy | 2025/12/15 14:55:04 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | On branch main
updater | Your branch is up to date with 'origin/main'.
updater | 
updater | nothing to commit, working tree clean
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2025/12/15 14:55:06 INFO Starting job processing
updater | 2025/12/15 14:55:06 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2025/12/15 14:55:06 INFO Base commit SHA: 186a3bdd52a2693ae246937e065dca4fa950ab2e
updater | 2025/12/15 14:55:06 INFO Finished job processing
updater | 2025/12/15 14:55:06 INFO Starting job processing
  proxy | 2025/12/15 14:55:06 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:06 [002] * authenticating git server request (host: github.com)
  proxy | 2025/12/15 14:55:06 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [004] * authenticating git server request (host: github.com)
  proxy | 2025/12/15 14:55:07 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:07 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [008] * authenticating git server request (host: github.com)
  proxy | 2025/12/15 14:55:07 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [010] * authenticating git server request (host: github.com)
  proxy | 2025/12/15 14:55:07 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:07 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [017] POST http://host.docker.internal:33901/update_jobs/cli/update_dependency_list
  proxy | 2025/12/15 14:55:08 [017] 200 http://host.docker.internal:33901/update_jobs/cli/update_dependency_list
  proxy | 2025/12/15 14:55:08 [018] POST http://host.docker.internal:33901/update_jobs/cli/increment_metric
  proxy | 2025/12/15 14:55:08 [018] 200 http://host.docker.internal:33901/update_jobs/cli/increment_metric
updater | 2025/12/15 14:55:08 INFO Starting grouped update job for not/used
updater | 2025/12/15 14:55:08 INFO Found 1 group(s).
updater | 2025/12/15 14:55:08 INFO Starting update group for 'actions'
updater | 2025/12/15 14:55:08 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2025/12/15 14:55:08 INFO Job specified dependencies: 
updater | 2025/12/15 14:55:08 INFO Updating the / directory.
  proxy | 2025/12/15 14:55:08 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:08 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:08 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:09 INFO Checking if actions/checkout 6 needs updating
  proxy | 2025/12/15 14:55:09 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:09 INFO Available release version/ref is 6
updater | 2025/12/15 14:55:09 INFO Latest version is 6
updater | 2025/12/15 14:55:09 INFO Adding dependencies as handled: (actions/checkout).
updater | 2025/12/15 14:55:09 INFO No update needed for actions/checkout 6
  proxy | 2025/12/15 14:55:09 [038] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [038] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [040] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [040] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [042] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [042] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [044] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [044] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [046] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [046] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [048] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [048] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:09 [050] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:09 [050] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:10 [052] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [052] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:10 INFO Checking if peter-evans/create-pull-request 7 needs updating
  proxy | 2025/12/15 14:55:10 [054] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [054] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:10 INFO Available release version/ref is 8
updater | 2025/12/15 14:55:10 INFO Latest version is 8
updater | 2025/12/15 14:55:10 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
  proxy | 2025/12/15 14:55:10 [056] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [056] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:10 [058] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [058] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:10 [060] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [060] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:10 [062] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [062] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:10 INFO Requirements to unlock own
updater | 2025/12/15 14:55:10 INFO Requirements update strategy 
  proxy | 2025/12/15 14:55:10 [064] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [064] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:10 [066] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:10 [066] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [068] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [068] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [070] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [070] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [072] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [072] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [074] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [074] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [076] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [076] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [078] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [078] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:11 INFO Creating dependency change for peter-evans/create-pull-request (8) in group actions
updater | 2025/12/15 14:55:11 INFO Updating peter-evans/create-pull-request from 7 to 8
  proxy | 2025/12/15 14:55:11 [080] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [080] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [082] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [082] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:11 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:11 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [088] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [088] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [090] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [090] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [092] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [092] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [094] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [094] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:12 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2025/12/15 14:55:12 [096] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [096] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:12 INFO Available release version/ref is 31
updater | 2025/12/15 14:55:12 INFO Latest version is 31
updater | 2025/12/15 14:55:12 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2025/12/15 14:55:12 INFO No update needed for cachix/install-nix-action 31
  proxy | 2025/12/15 14:55:12 [098] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [098] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [100] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [100] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [102] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [102] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:12 [104] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:12 [104] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:13 [106] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:13 [106] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:13 [108] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:13 [108] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:13 [110] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:13 [110] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2025/12/15 14:55:13 [112] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:13 [112] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:13 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2025/12/15 14:55:13 [114] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2025/12/15 14:55:13 [114] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
updater | 2025/12/15 14:55:13 INFO Available release version/ref is 1
updater | 2025/12/15 14:55:13 INFO Latest version is 1
updater | 2025/12/15 14:55:13 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2025/12/15 14:55:13 INFO No update needed for serokell/xrefcheck-action 1
updater | 2025/12/15 14:55:13 INFO Creating a pull request for 'actions'
  proxy | 2025/12/15 14:55:13 [116] GET https://api.github.com:443/repos/not/used/commits?per_page=100
  proxy | 2025/12/15 14:55:13 [116] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:13 [116] 404 https://api.github.com:443/repos/not/used/commits?per_page=100
  proxy | 2025/12/15 14:55:13 [116] * auth'd github api request failed authentication, retrying with alternate provided auth
  proxy | 2025/12/15 14:55:13 [116] * re-auth'd request returned 404, ignoring response
  proxy | 2025/12/15 14:55:14 [118] GET https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
  proxy | 2025/12/15 14:55:14 [118] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:14 [118] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
  proxy | 2025/12/15 14:55:14 [120] GET https://api.github.com:443/repos/peter-evans/create-pull-request/contents/
  proxy | 2025/12/15 14:55:14 [120] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:14 [120] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/contents/
  proxy | 2025/12/15 14:55:14 [122] GET https://api.github.com:443/repos/peter-evans/create-pull-request/contents/docs
  proxy | 2025/12/15 14:55:14 [122] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:15 [122] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/contents/docs
  proxy | 2025/12/15 14:55:15 [124] GET https://api.github.com:443/repos/peter-evans/create-pull-request/contents/?ref=v8
  proxy | 2025/12/15 14:55:15 [124] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:15 [124] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/contents/?ref=v8
  proxy | 2025/12/15 14:55:15 [126] GET https://api.github.com:443/repos/peter-evans/create-pull-request/contents/docs?ref=v8
  proxy | 2025/12/15 14:55:15 [126] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:15 [126] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/contents/docs?ref=v8
  proxy | 2025/12/15 14:55:15 [128] GET https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v7
  proxy | 2025/12/15 14:55:15 [128] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:15 [128] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v7
  proxy | 2025/12/15 14:55:15 [130] GET https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v8
  proxy | 2025/12/15 14:55:15 [130] * authenticating github api request with token for api.github.com
  proxy | 2025/12/15 14:55:15 [130] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v8
  proxy | 2025/12/15 14:55:15 [132] GET https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v7
  proxy | 2025/12/15 14:55:15 [132] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v7 (cached)
  proxy | 2025/12/15 14:55:15 [134] GET https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v8
  proxy | 2025/12/15 14:55:15 [134] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v8 (cached)
  proxy | 2025/12/15 14:55:15 [136] GET https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v7
  proxy | 2025/12/15 14:55:15 [136] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v7 (cached)
  proxy | 2025/12/15 14:55:16 [138] GET https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v8
  proxy | 2025/12/15 14:55:16 [138] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/commits?sha=v8 (cached)
  proxy | 2025/12/15 14:55:16 [139] POST http://host.docker.internal:33901/update_jobs/cli/create_pull_request
  proxy | 2025/12/15 14:55:16 [139] 200 http://host.docker.internal:33901/update_jobs/cli/create_pull_request
updater | 2025/12/15 14:55:16 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2025/12/15 14:55:16 [140] PATCH http://host.docker.internal:33901/update_jobs/cli/mark_as_processed
  proxy | 2025/12/15 14:55:16 [140] 200 http://host.docker.internal:33901/update_jobs/cli/mark_as_processed
updater | 2025/12/15 14:55:16 INFO Finished job processing
updater | 2025/12/15 14:55:16 INFO Results:
updater | +-----------------------------------------------------------+
updater | |            Changes to Dependabot Pull Requests            |
updater | +---------+-------------------------------------------------+
updater | | created | peter-evans/create-pull-request ( from 7 to 8 ) |
updater | +---------+-------------------------------------------------+
  proxy | 2025/12/15 14:55:16 Skipping sending metrics because api endpoint is empty
  proxy | 2025/12/15 14:55:16 56/68 calls cached (82%)
Bumps the actions group with 1 update: [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request).

Updates `peter-evans/create-pull-request` from 7 to 8
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/peter-evans/create-pull-request/releases">peter-evans/create-pull-request's releases</a>.</em></p>
<blockquote>
<h2>Create Pull Request v8.0.0</h2>
<h2>What's new in v8</h2>
<ul>
<li>Requires <a href="https://github.com/actions/runner/releases/tag/v2.327.1">Actions Runner v2.327.1</a> or later if you are using a self-hosted runner for Node 24 support.</li>
</ul>
<h2>What's Changed</h2>
<ul>
<li>chore: Update checkout action version to v6 by <a href="https://github.com/yonas"><code>@​yonas</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4258">peter-evans/create-pull-request#4258</a></li>
<li>Update actions/checkout references to <a href="https://github.com/v6"><code>@​v6</code></a> in docs by <a href="https://github.com/Copilot"><code>@​Copilot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4259">peter-evans/create-pull-request#4259</a></li>
<li>feat: v8 by <a href="https://github.com/peter-evans"><code>@​peter-evans</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4260">peter-evans/create-pull-request#4260</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/yonas"><code>@​yonas</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4258">peter-evans/create-pull-request#4258</a></li>
<li><a href="https://github.com/Copilot"><code>@​Copilot</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4259">peter-evans/create-pull-request#4259</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/peter-evans/create-pull-request/compare/v7.0.11...v8.0.0">https://github.com/peter-evans/create-pull-request/compare/v7.0.11...v8.0.0</a></p>
<h2>Create Pull Request v7.0.11</h2>
<h2>What's Changed</h2>
<ul>
<li>fix: restrict remote prune to self-hosted runners by <a href="https://github.com/peter-evans"><code>@​peter-evans</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4250">peter-evans/create-pull-request#4250</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/peter-evans/create-pull-request/compare/v7.0.10...v7.0.11">https://github.com/peter-evans/create-pull-request/compare/v7.0.10...v7.0.11</a></p>
<h2>Create Pull Request v7.0.10</h2>
<p>⚙️ Fixes an issue where updating a pull request failed when targeting a forked repository with the same owner as its parent.</p>
<h2>What's Changed</h2>
<ul>
<li>build(deps): bump the github-actions group with 2 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4235">peter-evans/create-pull-request#4235</a></li>
<li>build(deps-dev): bump prettier from 3.6.2 to 3.7.3 in the npm group by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4240">peter-evans/create-pull-request#4240</a></li>
<li>fix: provider list pulls fallback for multi fork same owner by <a href="https://github.com/peter-evans"><code>@​peter-evans</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4245">peter-evans/create-pull-request#4245</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/obnyis"><code>@​obnyis</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4064">peter-evans/create-pull-request#4064</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/peter-evans/create-pull-request/compare/v7.0.9...v7.0.10">https://github.com/peter-evans/create-pull-request/compare/v7.0.9...v7.0.10</a></p>
<h2>Create Pull Request v7.0.9</h2>
<p>⚙️ Fixes an <a href="https://redirect.github.com/peter-evans/create-pull-request/issues/4228">incompatibility</a> with the recently released <code>actions/checkout@v6</code>.</p>
<h2>What's Changed</h2>
<ul>
<li>~70 dependency updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a></li>
<li>docs: fix workaround description about <code>ready_for_review</code> by <a href="https://github.com/ybiquitous"><code>@​ybiquitous</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3939">peter-evans/create-pull-request#3939</a></li>
<li>Docs: <code>add-paths</code> default behavior by <a href="https://github.com/joeflack4"><code>@​joeflack4</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3928">peter-evans/create-pull-request#3928</a></li>
<li>docs: update to create-github-app-token v2 by <a href="https://github.com/Goooler"><code>@​Goooler</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4063">peter-evans/create-pull-request#4063</a></li>
<li>Fix compatibility with actions/checkout@v6 by <a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4230">peter-evans/create-pull-request#4230</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/joeflack4"><code>@​joeflack4</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3928">peter-evans/create-pull-request#3928</a></li>
<li><a href="https://github.com/Goooler"><code>@​Goooler</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4063">peter-evans/create-pull-request#4063</a></li>
<li><a href="https://github.com/ericsciple"><code>@​ericsciple</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/4230">peter-evans/create-pull-request#4230</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/98357b18bf14b5342f975ff684046ec3b2a07725"><code>98357b1</code></a> feat: v8 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/4260">#4260</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/41c0e4b7899a4a0922bf899d64c5f25738cfe356"><code>41c0e4b</code></a> Update actions/checkout references to <a href="https://github.com/v6"><code>@​v6</code></a> in docs (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/4259">#4259</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/994332de4c8124517167807167073cf397678768"><code>994332d</code></a> chore: Update checkout action version to v6 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/4258">#4258</a>)</li>
<li>See full diff in <a href="https://github.com/peter-evans/create-pull-request/compare/v7...v8">compare view</a></li>
</ul>
</details>
<br />

</details>
Running /nix/store/bzs50qcws1bjiw73mk91ix7z5vdsdhnc-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    revision: 96ca3529c27caa2ba3e8c17327ec551193cb12dd
+    revision: 88b3c158c151e06b34b978b59eb8196df370ef83
-    url: https://github.com/nixos/nixpkgs/archive/96ca3529c27caa2ba3e8c17327ec551193cb12dd.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/88b3c158c151e06b34b978b59eb8196df370ef83.tar.gz
-    hash: 0df8d2x0sxkcf13863qssxlp67gcbi29dmgcb78h337n99l47qf6
+    hash: 0gygfkb5gxsgbhrcswb7hkz8xvvsll98snsj3rlb01q97258ndra
[INFO ] Update successful.
```
</details>
