### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -87,9 +87,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -133,11 +133,11 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -179,18 +179,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -219,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -278,15 +278,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
@@ -389,18 +389,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -497,15 +497,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -513,12 +513,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -564,15 +558,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -595,9 +589,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -615,15 +609,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -681,9 +675,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -696,15 +690,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -713,77 +698,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2024"
 [dependencies]
 rnix = "0.12.0"
 regex = "1.12.2"
-clap = { version = "4.5.53", features = ["derive"] }
-serde_json = "1.0.145"
-tempfile = "3.23.0"
+clap = { version = "4.5.54", features = ["derive"] }
+serde_json = "1.0.149"
+tempfile = "3.24.0"
 serde = { version = "1.0.228", features = ["derive"] }
 anyhow = "1.0"
-colored = "3.0.0"
+colored = "3.1.1"
 itertools = "0.14.0"
 rowan = "0.15.17"
 indoc = "2.0.7"
@@ -19,7 +19,7 @@ relative-path = "2.0.1"
 textwrap = "0.16.2"
 derive-enum-from-into = "0.2.1"
 derive-new = "0.7.0"
-derive_more = { version = "2.1.0", features = ["display"] }
+derive_more = { version = "2.1.1", features = ["display"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "04fa1e1c4c1f3b9f030de22c7bea2181ff58fae5",
-      "url": "https://github.com/nixos/nixpkgs/archive/04fa1e1c4c1f3b9f030de22c7bea2181ff58fae5.tar.gz",
-      "hash": "sha256-FtwlPV/Amkr/qWoGf3V5GGnyd/QzRG9SxPKi0275UIc="
+      "revision": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
+      "url": "https://github.com/nixos/nixpkgs/archive/13b0f9e6ac78abbbb736c635d87845c4f4bee51b.tar.gz",
+      "hash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/9xhn4iisqcagw3151mzw0rfm2am4g01l-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name        old req compatible latest  new req
====        ======= ========== ======  =======
clap        4.5.53  4.5.54     4.5.54  4.5.54 
serde_json  1.0.145 1.0.149    1.0.149 1.0.149
tempfile    3.23.0  3.24.0     3.24.0  3.24.0 
colored     3.0.0   3.1.1      3.1.1   3.1.1  
derive_more 2.1.0   2.1.1      2.1.1   2.1.1  
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.92.0 compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 12 packages

```
### cargo update

```
    Updating crates.io index
     Locking 8 packages to latest Rust 1.92.0 compatible versions
    Updating clap_lex v0.7.6 -> v0.7.7
    Updating itoa v1.0.15 -> v1.0.17
    Updating libc v0.2.178 -> v0.2.180
    Updating proc-macro2 v1.0.103 -> v1.0.106
    Updating quote v1.0.42 -> v1.0.44
    Updating syn v2.0.111 -> v2.0.114
    Updating wasip2 v1.0.1+wasi-0.2.4 -> v1.0.2+wasi-0.2.9
    Updating wit-bindgen v0.46.0 -> v0.51.0
note: pass `--verbose` to see 1 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 904 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (84 crate dependencies)

```
</details>
Running /nix/store/pz0bg3xp4zr5rfmjdlr548b52381fvbv-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.81.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.81.0
    cli | 2026/01/26 13:21:04 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2026/01/26 13:21:05 proxy starting, commit: e2eedad0159c7c41eb7f476ec4d5b033af252576
  proxy | 2026/01/26 13:21:05 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/01/26 13:21:07 INFO Starting job processing
updater | 2026/01/26 13:21:07 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/01/26 13:21:08 INFO Base commit SHA: cad60cdf89ffd554a189e07202f9acafc4ffe41e
updater | 2026/01/26 13:21:08 INFO Finished job processing
updater | 2026/01/26 13:21:08 INFO Starting job processing
  proxy | 2026/01/26 13:21:08 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:08 [002] * authenticating git server request (host: github.com)
  proxy | 2026/01/26 13:21:08 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:08 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:08 [004] * authenticating git server request (host: github.com)
  proxy | 2026/01/26 13:21:08 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:08 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:08 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:08 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:08 [008] * authenticating git server request (host: github.com)
  proxy | 2026/01/26 13:21:08 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [010] * authenticating git server request (host: github.com)
  proxy | 2026/01/26 13:21:09 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:09 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:09 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:09 [017] POST http://host.docker.internal:33953/update_jobs/cli/update_dependency_list
  proxy | 2026/01/26 13:21:09 [017] 200 http://host.docker.internal:33953/update_jobs/cli/update_dependency_list
  proxy | 2026/01/26 13:21:09 [018] POST http://host.docker.internal:33953/update_jobs/cli/increment_metric
  proxy | 2026/01/26 13:21:09 [018] 200 http://host.docker.internal:33953/update_jobs/cli/increment_metric
updater | 2026/01/26 13:21:09 INFO Starting grouped update job for not/used
updater | 2026/01/26 13:21:09 INFO Found 1 group(s).
updater | 2026/01/26 13:21:09 INFO Starting update group for 'actions'
updater | 2026/01/26 13:21:09 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2026/01/26 13:21:09 INFO Job specified dependencies: 
updater | 2026/01/26 13:21:09 INFO Updating the / directory.
  proxy | 2026/01/26 13:21:09 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:09 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:09 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:09 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:10 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:10 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:10 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:10 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:10 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:10 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:10 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:10 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:10 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:10 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/01/26 13:21:10 INFO Checking if actions/checkout 6 needs updating
  proxy | 2026/01/26 13:21:10 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:10 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:10 [038] GET https://api.github.com:443/repos/actions/checkout/releases?per_page=100
  proxy | 2026/01/26 13:21:10 [038] * authenticating github api request with token for api.github.com
  proxy | 2026/01/26 13:21:11 [038] 200 https://api.github.com:443/repos/actions/checkout/releases?per_page=100
updater | 2026/01/26 13:21:11 INFO Available release version/ref is 6
updater | 2026/01/26 13:21:11 INFO Latest version is 6
updater | 2026/01/26 13:21:11 INFO Adding dependencies as handled: (actions/checkout).
updater | 2026/01/26 13:21:11 INFO No update needed for actions/checkout 6
  proxy | 2026/01/26 13:21:11 [040] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [040] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [042] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [042] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [044] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [044] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [046] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [046] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [048] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [048] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [050] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [050] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [052] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [052] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:11 [054] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:11 [054] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/01/26 13:21:11 INFO Checking if peter-evans/create-pull-request 8 needs updating
  proxy | 2026/01/26 13:21:12 [056] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:12 [056] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:12 [058] GET https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
  proxy | 2026/01/26 13:21:12 [058] * authenticating github api request with token for api.github.com
  proxy | 2026/01/26 13:21:12 [058] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
updater | 2026/01/26 13:21:12 INFO Available release version/ref is 8
updater | 2026/01/26 13:21:12 INFO Latest version is 8
updater | 2026/01/26 13:21:12 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
updater | 2026/01/26 13:21:12 INFO No update needed for peter-evans/create-pull-request 8
  proxy | 2026/01/26 13:21:12 [060] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:12 [060] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:12 [062] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:12 [062] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [064] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [064] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [066] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [066] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [068] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [068] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [070] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [070] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [072] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [072] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [074] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [074] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/01/26 13:21:13 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2026/01/26 13:21:13 [076] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:13 [076] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:13 [078] GET https://api.github.com:443/repos/cachix/install-nix-action/releases?per_page=100
  proxy | 2026/01/26 13:21:13 [078] * authenticating github api request with token for api.github.com
  proxy | 2026/01/26 13:21:13 [078] 200 https://api.github.com:443/repos/cachix/install-nix-action/releases?per_page=100
updater | 2026/01/26 13:21:13 INFO Available release version/ref is 31
updater | 2026/01/26 13:21:13 INFO Latest version is 31
updater | 2026/01/26 13:21:13 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2026/01/26 13:21:13 INFO No update needed for cachix/install-nix-action 31
  proxy | 2026/01/26 13:21:14 [080] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [080] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [082] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [082] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [088] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [088] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [090] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [090] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [092] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [092] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [094] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [094] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/01/26 13:21:14 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2026/01/26 13:21:14 [096] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/01/26 13:21:14 [096] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/01/26 13:21:14 [098] GET https://api.github.com:443/repos/serokell/xrefcheck-action/releases?per_page=100
  proxy | 2026/01/26 13:21:14 [098] * authenticating github api request with token for api.github.com
  proxy | 2026/01/26 13:21:15 [098] 200 https://api.github.com:443/repos/serokell/xrefcheck-action/releases?per_page=100
updater | 2026/01/26 13:21:15 INFO Available release version/ref is 1
updater | 2026/01/26 13:21:15 INFO Latest version is 1
updater | 2026/01/26 13:21:15 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2026/01/26 13:21:15 INFO No update needed for serokell/xrefcheck-action 1
updater | 2026/01/26 13:21:15 INFO Nothing to update for Dependency Group: 'actions'
updater | 2026/01/26 13:21:15 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2026/01/26 13:21:15 [099] PATCH http://host.docker.internal:33953/update_jobs/cli/mark_as_processed
  proxy | 2026/01/26 13:21:15 [099] 200 http://host.docker.internal:33953/update_jobs/cli/mark_as_processed
updater | 2026/01/26 13:21:15 INFO Finished job processing
  proxy | 2026/01/26 13:21:15 Skipping sending metrics because api endpoint is empty
  proxy | 2026/01/26 13:21:15 40/48 calls cached (83%)
</details>
Running /nix/store/6cz8vx327ljxq64bkmgsg8vqc3lqm56v-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    revision: 04fa1e1c4c1f3b9f030de22c7bea2181ff58fae5
+    revision: 13b0f9e6ac78abbbb736c635d87845c4f4bee51b
-    url: https://github.com/nixos/nixpkgs/archive/04fa1e1c4c1f3b9f030de22c7bea2181ff58fae5.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/13b0f9e6ac78abbbb736c635d87845c4f4bee51b.tar.gz
-    hash: sha256-FtwlPV/Amkr/qWoGf3V5GGnyd/QzRG9SxPKi0275UIc=
+    hash: sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=
[INFO ] Update successful.
```
</details>
