### PR TITLE
CODEOWNERS: replace nixpkgs-vet with nixpkgs-ci team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @NixOS/nixpkgs-vet
+* @NixOS/nixpkgs-ci


### PR DESCRIPTION
After NixOS/org#164, the CODEOWNERS file has been broken.
