### PR TITLE
npins: switch nixpkgs from master branch back to nixpkgs-unstable channel

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,17 +1,10 @@
 {
   "pins": {
     "nixpkgs": {
-      "type": "Git",
-      "repository": {
-        "type": "GitHub",
-        "owner": "nixos",
-        "repo": "nixpkgs"
-      },
-      "branch": "master",
-      "submodules": false,
-      "revision": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
-      "url": "https://github.com/nixos/nixpkgs/archive/13b0f9e6ac78abbbb736c635d87845c4f4bee51b.tar.gz",
-      "hash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs="
+      "type": "Channel",
+      "name": "nixpkgs-unstable",
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre934390.48698d12cc10/nixexprs.tar.xz",
+      "hash": "sha256-YpOjLmOGokqTiFjxFu0ioMpMbxHGP6CckfgmqV5OAck="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Undoes 4010f1dc9679874e9e32209898f22288061358d9 -- no longer needed.

See also https://github.com/NixOS/nixpkgs-vet/pull/179#discussion_r2386447842.
