### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -711,6 +711,6 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 rnix = "0.12.0"
 regex = "1.12.2"
-clap = { version = "4.5.54", features = ["derive"] }
+clap = { version = "4.5.56", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.24.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre934390.48698d12cc10/nixexprs.tar.xz",
-      "hash": "sha256-YpOjLmOGokqTiFjxFu0ioMpMbxHGP6CckfgmqV5OAck="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre938800.f08e6b11a5ed/nixexprs.tar.xz",
+      "hash": "sha256-SYiwVUy/8bjZRMQtf760lbpATzVJDsl/6ffk0VLj03I="
     },
     "treefmt-nix": {
       "type": "Git",
@@ -15,9 +15,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "f46bb205f239b415309f58166f8df6919fa88377",
-      "url": "https://github.com/numtide/treefmt-nix/archive/f46bb205f239b415309f58166f8df6919fa88377.tar.gz",
-      "hash": "sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ="
+      "revision": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
+      "url": "https://github.com/numtide/treefmt-nix/archive/28b19c5844cc6e2257801d43f2772a4b4c050a1b.tar.gz",
+      "hash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM="
     }
   },
   "version": 7


### PR DESCRIPTION
Running /nix/store/9xhn4iisqcagw3151mzw0rfm2am4g01l-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.54  4.5.56     4.5.56 4.5.56 
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.92.0 compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rnix, rowan
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
     Locking 1 package to latest Rust 1.92.0 compatible version
    Updating zmij v1.0.17 -> v1.0.19
note: pass `--verbose` to see 2 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rnix                0.12.0   ---     0.13.0   Normal  ---
rnix->rowan         0.15.17  ---     0.16.1   Normal  ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 907 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (84 crate dependencies)

```
</details>
Running /nix/store/pz0bg3xp4zr5rfmjdlr548b52381fvbv-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.81.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.81.0
    cli | 2026/02/02 15:02:39 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2026/02/02 15:02:40 proxy starting, commit: e2eedad0159c7c41eb7f476ec4d5b033af252576
  proxy | 2026/02/02 15:02:40 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/02/02 15:02:42 INFO Starting job processing
updater | 2026/02/02 15:02:42 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/02/02 15:02:43 INFO Base commit SHA: 6741b820533087168ff36be70aa9ad62ab4df8b4
updater | 2026/02/02 15:02:43 INFO Finished job processing
updater | 2026/02/02 15:02:43 INFO Starting job processing
  proxy | 2026/02/02 15:02:43 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [002] * authenticating git server request (host: github.com)
  proxy | 2026/02/02 15:02:43 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [004] * authenticating git server request (host: github.com)
  proxy | 2026/02/02 15:02:43 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:43 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [008] * authenticating git server request (host: github.com)
  proxy | 2026/02/02 15:02:43 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:43 [010] * authenticating git server request (host: github.com)
  proxy | 2026/02/02 15:02:43 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [017] POST http://host.docker.internal:39647/update_jobs/cli/update_dependency_list
  proxy | 2026/02/02 15:02:44 [017] 200 http://host.docker.internal:39647/update_jobs/cli/update_dependency_list
  proxy | 2026/02/02 15:02:44 [018] POST http://host.docker.internal:39647/update_jobs/cli/increment_metric
  proxy | 2026/02/02 15:02:44 [018] 200 http://host.docker.internal:39647/update_jobs/cli/increment_metric
updater | 2026/02/02 15:02:44 INFO Starting grouped update job for not/used
updater | 2026/02/02 15:02:44 INFO Found 1 group(s).
updater | 2026/02/02 15:02:44 INFO Starting update group for 'actions'
updater | 2026/02/02 15:02:44 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2026/02/02 15:02:44 INFO Job specified dependencies: 
updater | 2026/02/02 15:02:44 INFO Updating the / directory.
  proxy | 2026/02/02 15:02:44 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:44 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:44 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:45 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:45 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:45 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:45 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/02 15:02:45 INFO Checking if actions/checkout 6 needs updating
  proxy | 2026/02/02 15:02:45 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:45 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:45 [038] GET https://api.github.com:443/repos/actions/checkout/releases?per_page=100
  proxy | 2026/02/02 15:02:45 [038] * authenticating github api request with token for api.github.com
  proxy | 2026/02/02 15:02:45 [038] 200 https://api.github.com:443/repos/actions/checkout/releases?per_page=100
updater | 2026/02/02 15:02:45 INFO Available release version/ref is 6
updater | 2026/02/02 15:02:45 INFO Latest version is 6
updater | 2026/02/02 15:02:45 INFO Adding dependencies as handled: (actions/checkout).
updater | 2026/02/02 15:02:45 INFO No update needed for actions/checkout 6
  proxy | 2026/02/02 15:02:45 [040] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:45 [040] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [042] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [042] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [044] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [044] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [046] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [046] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [048] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [048] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [050] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [050] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [052] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [052] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [054] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [054] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/02 15:02:46 INFO Checking if peter-evans/create-pull-request 8 needs updating
  proxy | 2026/02/02 15:02:46 [056] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:46 [056] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:46 [058] GET https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
  proxy | 2026/02/02 15:02:46 [058] * authenticating github api request with token for api.github.com
  proxy | 2026/02/02 15:02:47 [058] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
updater | 2026/02/02 15:02:47 INFO Available release version/ref is 8
updater | 2026/02/02 15:02:47 INFO Latest version is 8
updater | 2026/02/02 15:02:47 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
updater | 2026/02/02 15:02:47 INFO No update needed for peter-evans/create-pull-request 8
  proxy | 2026/02/02 15:02:47 [060] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:47 [060] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:47 [062] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:47 [062] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:47 [064] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:47 [064] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:47 [066] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:47 [066] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:47 [068] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:47 [068] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:47 [070] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:47 [070] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:48 [072] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:48 [072] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:48 [074] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:48 [074] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/02 15:02:48 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2026/02/02 15:02:48 [076] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:48 [076] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:48 [078] GET https://api.github.com:443/repos/cachix/install-nix-action/releases?per_page=100
  proxy | 2026/02/02 15:02:48 [078] * authenticating github api request with token for api.github.com
  proxy | 2026/02/02 15:02:48 [078] 200 https://api.github.com:443/repos/cachix/install-nix-action/releases?per_page=100
updater | 2026/02/02 15:02:48 INFO Available release version/ref is 31
updater | 2026/02/02 15:02:48 INFO Latest version is 31
updater | 2026/02/02 15:02:48 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2026/02/02 15:02:48 INFO No update needed for cachix/install-nix-action 31
  proxy | 2026/02/02 15:02:48 [080] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:48 [080] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:48 [082] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:48 [082] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:48 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:48 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:49 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:49 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:49 [088] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:49 [088] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:49 [090] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:49 [090] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:49 [092] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:49 [092] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:49 [094] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:49 [094] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/02 15:02:49 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2026/02/02 15:02:49 [096] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/02 15:02:49 [096] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/02 15:02:49 [098] GET https://api.github.com:443/repos/serokell/xrefcheck-action/releases?per_page=100
  proxy | 2026/02/02 15:02:49 [098] * authenticating github api request with token for api.github.com
  proxy | 2026/02/02 15:02:49 [098] 200 https://api.github.com:443/repos/serokell/xrefcheck-action/releases?per_page=100
updater | 2026/02/02 15:02:49 INFO Available release version/ref is 1
updater | 2026/02/02 15:02:49 INFO Latest version is 1
updater | 2026/02/02 15:02:49 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2026/02/02 15:02:49 INFO No update needed for serokell/xrefcheck-action 1
updater | 2026/02/02 15:02:49 INFO Nothing to update for Dependency Group: 'actions'
updater | 2026/02/02 15:02:49 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2026/02/02 15:02:49 [099] PATCH http://host.docker.internal:39647/update_jobs/cli/mark_as_processed
  proxy | 2026/02/02 15:02:49 [099] 200 http://host.docker.internal:39647/update_jobs/cli/mark_as_processed
updater | 2026/02/02 15:02:49 INFO Finished job processing
  proxy | 2026/02/02 15:02:49 40/48 calls cached (83%)
  proxy | 2026/02/02 15:02:49 Skipping sending metrics because api endpoint is empty
</details>
Running /nix/store/6cz8vx327ljxq64bkmgsg8vqc3lqm56v-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: f46bb205f239b415309f58166f8df6919fa88377
+    revision: 28b19c5844cc6e2257801d43f2772a4b4c050a1b
-    url: https://github.com/numtide/treefmt-nix/archive/f46bb205f239b415309f58166f8df6919fa88377.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/28b19c5844cc6e2257801d43f2772a4b4c050a1b.tar.gz
-    hash: sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ=
+    hash: sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre934390.48698d12cc10/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre938800.f08e6b11a5ed/nixexprs.tar.xz
-    hash: sha256-YpOjLmOGokqTiFjxFu0ioMpMbxHGP6CckfgmqV5OAck=
+    hash: sha256-SYiwVUy/8bjZRMQtf760lbpATzVJDsl/6ffk0VLj03I=
[INFO ] Update successful.
```
</details>
