### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "autocfg"
@@ -87,9 +87,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relative-path"
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-linebreak"
@@ -711,6 +711,6 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 
 [dependencies]
 rnix = "0.12.0"
-regex = "1.12.2"
-clap = { version = "4.5.56", features = ["derive"] }
+regex = "1.12.3"
+clap = { version = "4.5.57", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.24.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre938800.f08e6b11a5ed/nixexprs.tar.xz",
-      "hash": "sha256-SYiwVUy/8bjZRMQtf760lbpATzVJDsl/6ffk0VLj03I="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre942631.fef9403a3e4d/nixexprs.tar.xz",
+      "hash": "sha256-XV30uo8tXuxdzuV8l3sojmlPRLd/8tpMsOp4lNzLGUo="
     },
     "treefmt-nix": {
       "type": "Git",
@@ -15,9 +15,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
-      "url": "https://github.com/numtide/treefmt-nix/archive/28b19c5844cc6e2257801d43f2772a4b4c050a1b.tar.gz",
-      "hash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM="
+      "revision": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+      "url": "https://github.com/numtide/treefmt-nix/archive/337a4fe074be1042a35086f15481d763b8ddc0e7.tar.gz",
+      "hash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk="
     }
   },
   "version": 7


### PR DESCRIPTION
Running /nix/store/9xhn4iisqcagw3151mzw0rfm2am4g01l-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name  old req compatible latest new req
====  ======= ========== ====== =======
regex 1.12.2  1.12.3     1.12.3 1.12.3 
clap  4.5.56  4.5.57     4.5.57 4.5.57 
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.92.0 compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rnix, rowan
  latest: 14 packages

```
### cargo update

```
    Updating crates.io index
     Locking 6 packages to latest Rust 1.92.0 compatible versions
    Updating anyhow v1.0.100 -> v1.0.101
    Updating memchr v2.7.6 -> v2.8.0
    Updating regex-automata v0.4.13 -> v0.4.14
    Updating regex-syntax v0.8.8 -> v0.8.9
    Updating unicode-ident v1.0.22 -> v1.0.23
    Updating zmij v1.0.19 -> v1.0.20
note: pass `--verbose` to see 2 unchanged dependencies behind latest

```
### cargo outdated

```
Name                Project  Compat  Latest   Kind    Platform
----                -------  ------  ------   ----    --------
memoffset->autocfg  1.5.0    ---     Removed  Build   ---
rnix                0.12.0   ---     0.13.0   Normal  ---
rnix->rowan         0.15.17  ---     0.16.1   Normal  ---
rowan               0.15.17  ---     0.16.1   Normal  ---
rowan->memoffset    0.9.1    ---     Removed  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 916 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (84 crate dependencies)

```
</details>
Running /nix/store/vdkr59zh12mlv0alj447d0wlmhvlqrfh-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.81.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.81.0
    cli | 2026/02/09 15:07:57 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | 2026/02/09 15:07:58 proxy starting, commit: e2eedad0159c7c41eb7f476ec4d5b033af252576
  proxy | 2026/02/09 15:07:58 Listening (:1080)
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/02/09 15:08:01 INFO Starting job processing
updater | 2026/02/09 15:08:01 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/02/09 15:08:01 INFO Base commit SHA: 382616f5974d3d588a30ab0fc0c14f7314bdd1e2
updater | 2026/02/09 15:08:01 INFO Finished job processing
updater | 2026/02/09 15:08:01 INFO Starting job processing
  proxy | 2026/02/09 15:08:01 [002] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:01 [002] * authenticating git server request (host: github.com)
  proxy | 2026/02/09 15:08:01 [002] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:01 [004] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:01 [004] * authenticating git server request (host: github.com)
  proxy | 2026/02/09 15:08:02 [004] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [006] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [006] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:02 [008] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [008] * authenticating git server request (host: github.com)
  proxy | 2026/02/09 15:08:02 [008] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [010] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [010] * authenticating git server request (host: github.com)
  proxy | 2026/02/09 15:08:02 [010] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [012] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [012] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:02 [014] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:02 [014] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [016] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [016] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [017] POST http://host.docker.internal:44165/update_jobs/cli/update_dependency_list
  proxy | 2026/02/09 15:08:03 [017] 200 http://host.docker.internal:44165/update_jobs/cli/update_dependency_list
  proxy | 2026/02/09 15:08:03 [018] POST http://host.docker.internal:44165/update_jobs/cli/increment_metric
  proxy | 2026/02/09 15:08:03 [018] 200 http://host.docker.internal:44165/update_jobs/cli/increment_metric
updater | 2026/02/09 15:08:03 INFO Starting grouped update job for not/used
updater | 2026/02/09 15:08:03 INFO Found 1 group(s).
updater | 2026/02/09 15:08:03 INFO Starting update group for 'actions'
updater | 2026/02/09 15:08:03 INFO Dependency Snapshot: actions/checkout, peter-evans/create-pull-request, cachix/install-nix-action, serokell/xrefcheck-action
updater | 2026/02/09 15:08:03 INFO Job specified dependencies: 
updater | 2026/02/09 15:08:03 INFO Updating the / directory.
  proxy | 2026/02/09 15:08:03 [020] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [020] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [022] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [022] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [024] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [024] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [026] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [026] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [028] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [028] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [030] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [030] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:03 [032] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:03 [032] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:04 [034] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:04 [034] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/09 15:08:04 INFO Checking if actions/checkout 6 needs updating
  proxy | 2026/02/09 15:08:04 [036] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:04 [036] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:04 [038] GET https://api.github.com:443/repos/actions/checkout/releases?per_page=100
  proxy | 2026/02/09 15:08:04 [038] * authenticating github api request with token for api.github.com
  proxy | 2026/02/09 15:08:04 [038] 200 https://api.github.com:443/repos/actions/checkout/releases?per_page=100
updater | 2026/02/09 15:08:04 INFO Available release version/ref is 6
updater | 2026/02/09 15:08:04 INFO Latest version is 6
updater | 2026/02/09 15:08:04 INFO Adding dependencies as handled: (actions/checkout).
updater | 2026/02/09 15:08:04 INFO No update needed for actions/checkout 6
  proxy | 2026/02/09 15:08:05 [040] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [040] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [042] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [042] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [044] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [044] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [046] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [046] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [048] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [048] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [050] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [050] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [052] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [052] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:05 [054] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [054] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/09 15:08:05 INFO Checking if peter-evans/create-pull-request 8 needs updating
  proxy | 2026/02/09 15:08:05 [056] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:05 [056] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:06 [058] GET https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
  proxy | 2026/02/09 15:08:06 [058] * authenticating github api request with token for api.github.com
  proxy | 2026/02/09 15:08:06 [058] 200 https://api.github.com:443/repos/peter-evans/create-pull-request/releases?per_page=100
updater | 2026/02/09 15:08:06 INFO Available release version/ref is 8
updater | 2026/02/09 15:08:06 INFO Latest version is 8
updater | 2026/02/09 15:08:06 INFO Adding dependencies as handled: (peter-evans/create-pull-request).
updater | 2026/02/09 15:08:06 INFO No update needed for peter-evans/create-pull-request 8
  proxy | 2026/02/09 15:08:06 [060] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:06 [060] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:06 [062] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:06 [062] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [064] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [064] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [066] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [066] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [068] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [068] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [070] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [070] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [072] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [072] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [074] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [074] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/09 15:08:07 INFO Checking if cachix/install-nix-action 31 needs updating
  proxy | 2026/02/09 15:08:07 [076] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:07 [076] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:07 [078] GET https://api.github.com:443/repos/cachix/install-nix-action/releases?per_page=100
  proxy | 2026/02/09 15:08:07 [078] * authenticating github api request with token for api.github.com
  proxy | 2026/02/09 15:08:08 [078] 200 https://api.github.com:443/repos/cachix/install-nix-action/releases?per_page=100
updater | 2026/02/09 15:08:08 INFO Available release version/ref is 31
updater | 2026/02/09 15:08:08 INFO Latest version is 31
updater | 2026/02/09 15:08:08 INFO Adding dependencies as handled: (cachix/install-nix-action).
updater | 2026/02/09 15:08:08 INFO No update needed for cachix/install-nix-action 31
  proxy | 2026/02/09 15:08:08 [080] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [080] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [082] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [082] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [084] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [084] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [086] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [086] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [088] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [088] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [090] GET https://github.com/actions/checkout.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [090] 200 https://github.com/actions/checkout.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [092] GET https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [092] 200 https://github.com/cachix/install-nix-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:08 [094] GET https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:08 [094] 200 https://github.com/peter-evans/create-pull-request.git/info/refs?service=git-upload-pack (cached)
updater | 2026/02/09 15:08:08 INFO Checking if serokell/xrefcheck-action 1 needs updating
  proxy | 2026/02/09 15:08:09 [096] GET https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack
  proxy | 2026/02/09 15:08:09 [096] 200 https://github.com/serokell/xrefcheck-action.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/02/09 15:08:09 [098] GET https://api.github.com:443/repos/serokell/xrefcheck-action/releases?per_page=100
  proxy | 2026/02/09 15:08:09 [098] * authenticating github api request with token for api.github.com
  proxy | 2026/02/09 15:08:09 [098] 200 https://api.github.com:443/repos/serokell/xrefcheck-action/releases?per_page=100
updater | 2026/02/09 15:08:09 INFO Available release version/ref is 1
updater | 2026/02/09 15:08:09 INFO Latest version is 1
updater | 2026/02/09 15:08:09 INFO Adding dependencies as handled: (serokell/xrefcheck-action).
updater | 2026/02/09 15:08:09 INFO No update needed for serokell/xrefcheck-action 1
updater | 2026/02/09 15:08:09 INFO Nothing to update for Dependency Group: 'actions'
updater | 2026/02/09 15:08:09 INFO Found no dependencies to update after filtering allowed updates in /
  proxy | 2026/02/09 15:08:09 [099] PATCH http://host.docker.internal:44165/update_jobs/cli/mark_as_processed
  proxy | 2026/02/09 15:08:09 [099] 200 http://host.docker.internal:44165/update_jobs/cli/mark_as_processed
updater | 2026/02/09 15:08:09 INFO Finished job processing
  proxy | 2026/02/09 15:08:09 Skipping sending metrics because api endpoint is empty
  proxy | 2026/02/09 15:08:09 40/48 calls cached (83%)
</details>
Running /nix/store/yiazjyf15bspn6i5pb2l6pyy6fxfpjvh-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 28b19c5844cc6e2257801d43f2772a4b4c050a1b
+    revision: 337a4fe074be1042a35086f15481d763b8ddc0e7
-    url: https://github.com/numtide/treefmt-nix/archive/28b19c5844cc6e2257801d43f2772a4b4c050a1b.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/337a4fe074be1042a35086f15481d763b8ddc0e7.tar.gz
-    hash: sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=
+    hash: sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre938800.f08e6b11a5ed/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre942631.fef9403a3e4d/nixexprs.tar.xz
-    hash: sha256-SYiwVUy/8bjZRMQtf760lbpATzVJDsl/6ffk0VLj03I=
+    hash: sha256-XV30uo8tXuxdzuV8l3sojmlPRLd/8tpMsOp4lNzLGUo=
[INFO ] Update successful.
```
</details>
