### PR TITLE
Do not encourage merging with CI failure

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -20,8 +20,8 @@ pub enum Status {
     /// branch would break.
     ProblemsIntroduced(Vec<Problem>),
 
-    /// This PR introduces additional instances of discouraged patterns. Merging is discouraged but
-    /// would not break the base branch.
+    /// This PR introduces additional instances of discouraged patterns. Please fix them before
+    /// merging.
     DiscouragedPatternedIntroduced(Vec<Problem>),
 
     /// Some other error occurred.
@@ -70,7 +70,7 @@ impl Status {
             ),
             Self::DiscouragedPatternedIntroduced(..) => maybe_yellow(
                 "This PR introduces additional instances of discouraged patterns as listed above. \
-                 Merging is discouraged but would not break the base branch.",
+                 Please fix them before merging.",
             ),
         };
         fmt::Display::fmt(&message, f)

--- a/tests/manual-definition/expected
+++ b/tests/manual-definition/expected
@@ -18,4 +18,4 @@
 
   Such a definition is provided automatically and therefore not necessary. Please remove it.
 
-This PR introduces additional instances of discouraged patterns as listed above. Merging is discouraged but would not break the base branch.
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/move-to-non-by-name/expected
+++ b/tests/move-to-non-by-name/expected
@@ -10,4 +10,4 @@
 - Attribute `pkgs.foo4` was previously defined in pkgs/by-name/fo/foo4/package.nix, but is now manually defined as `callPackage ./with-config.nix { ... }` in pkgs/top-level/all-packages.nix.
   While the manual `callPackage` is still needed, it's not necessary to move the package files.
 
-This PR introduces additional instances of discouraged patterns as listed above. Merging is discouraged but would not break the base branch.
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/new-package-non-by-name/expected
+++ b/tests/new-package-non-by-name/expected
@@ -18,4 +18,4 @@
   See `pkgs/by-name/README.md` for more details.
   Since the second `callPackage` argument is not `{ }`, the manual `callPackage` in pkgs/top-level/all-packages.nix is still needed.
 
-This PR introduces additional instances of discouraged patterns as listed above. Merging is discouraged but would not break the base branch.
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/override-empty-arg/expected
+++ b/tests/override-empty-arg/expected
@@ -8,4 +8,4 @@
 
   Such a definition is provided automatically and therefore not necessary. Please remove it.
 
-This PR introduces additional instances of discouraged patterns as listed above. Merging is discouraged but would not break the base branch.
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/sorted-order/expected
+++ b/tests/sorted-order/expected
@@ -28,4 +28,4 @@
   See `pkgs/by-name/README.md` for more details.
   Since the second `callPackage` argument is `{ }`, no manual `callPackage` in pkgs/top-level/all-packages.nix is needed anymore.
 
-This PR introduces additional instances of discouraged patterns as listed above. Merging is discouraged but would not break the base branch.
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.


### PR DESCRIPTION
Replace "Merging is discouraged but would not break the base branch" with "Please fix them before merging" in the `DiscouragedPatternedIntroduced` status message. With required status checks now in place, the old message incorrectly reassured contributors that merging was safe despite a red CI check

Fixes #174