### PR TITLE
On .nix files, disallow executable bit without shebang (NPV-145) and shebang without executable bit (NPV-146)

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -1,9 +1,13 @@
 use relative_path::RelativePath;
 use relative_path::RelativePathBuf;
 use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use crate::nix_file::NixFileStore;
+use crate::problem::{npv_145, npv_146};
 use crate::validation::ResultIteratorExt;
 use crate::validation::Validation::Success;
 use crate::{nix_file, ratchet, structure, validation};
@@ -13,9 +17,9 @@ pub fn check_files(
     nixpkgs_path: &Path,
     nix_file_store: &mut NixFileStore,
 ) -> validation::Result<BTreeMap<RelativePathBuf, ratchet::File>> {
-    process_nix_files(nixpkgs_path, nix_file_store, |_nix_file| {
-        // Noop for now, only boilerplate to make it easier to add future file-based checks
-        Ok(Success(ratchet::File {}))
+    process_nix_files(nixpkgs_path, nix_file_store, |relative_path, nix_file| {
+        let result = check_executable_iff_shebang(relative_path, &nix_file.path)?;
+        Ok(result.map(|()| ratchet::File {}))
     })
 }
 
@@ -24,7 +28,7 @@ pub fn check_files(
 fn process_nix_files(
     nixpkgs_path: &Path,
     nix_file_store: &mut NixFileStore,
-    f: impl Fn(&nix_file::NixFile) -> validation::Result<ratchet::File>,
+    f: impl Fn(&RelativePath, &nix_file::NixFile) -> validation::Result<ratchet::File>,
 ) -> validation::Result<BTreeMap<RelativePathBuf, ratchet::File>> {
     // Get all Nix files
     let files = {
@@ -38,7 +42,7 @@ fn process_nix_files(
         .map(|path| {
             // Get the (optionally-cached) parsed Nix file
             let nix_file = nix_file_store.get(&path.to_path(nixpkgs_path))?;
-            let result = f(nix_file)?;
+            let result = f(&path, nix_file)?;
             let val = result.map(|ratchet| (path, ratchet));
             Ok::<_, anyhow::Error>(val)
         })
@@ -48,6 +52,30 @@ fn process_nix_files(
         // Convert the Vec to a BTreeMap
         entries.into_iter().collect()
     }))
+}
+
+/// Check that a Nix file is executable if and only if it has a shebang (`#!`) line.
+fn check_executable_iff_shebang(
+    relative_path: &RelativePath,
+    absolute_path: &Path,
+) -> validation::Result<()> {
+    let metadata = fs::metadata(absolute_path)?;
+    let mode = metadata.permissions().mode();
+    let is_executable = mode & 0o111 != 0;
+
+    let mut file = fs::File::open(absolute_path)?;
+    let mut buf = [0u8; 2];
+    let bytes_read = file.read(&mut buf)?;
+    let has_shebang = bytes_read >= 2 && buf == *b"#!";
+
+    match (is_executable, has_shebang) {
+        // Executable without shebang: error
+        (true, false) => Ok(npv_145::NixFileIsExecutableWithoutShebang::new(relative_path).into()),
+        // Shebang without executable: error
+        (false, true) => Ok(npv_146::NixFileHasShebangButNotExecutable::new(relative_path).into()),
+        // Both or neither: fine
+        _ => Ok(Success(())),
+    }
 }
 
 /// Recursively collects all Nix files in the relative `dir` within `base`

--- a/src/problem/mod.rs
+++ b/src/problem/mod.rs
@@ -31,6 +31,8 @@ pub mod npv_141;
 pub mod npv_142;
 pub mod npv_143;
 pub mod npv_144;
+pub mod npv_145;
+pub mod npv_146;
 
 pub mod npv_160;
 pub mod npv_161;
@@ -119,6 +121,12 @@ pub enum Problem {
     /// NPV-144: `package.nix` is not a file
     PackageNixIsNotFile(npv_144::PackageNixIsNotFile),
 
+    /// NPV-145: Nix file is executable without shebang
+    NixFileIsExecutableWithoutShebang(npv_145::NixFileIsExecutableWithoutShebang),
+
+    /// NPV-146: Nix file has shebang but is not executable
+    NixFileHasShebangButNotExecutable(npv_146::NixFileHasShebangButNotExecutable),
+
     /// NPV-160: top-level package moved out of by-name
     TopLevelPackageMovedOutOfByName(npv_160::TopLevelPackageMovedOutOfByName),
 
@@ -166,6 +174,8 @@ impl Problem {
             Self::PackageInWrongShard(..) => "NPV-142",
             Self::PackageNixMissing(..) => "NPV-143",
             Self::PackageNixIsNotFile(..) => "NPV-144",
+            Self::NixFileIsExecutableWithoutShebang(..) => "NPV-145",
+            Self::NixFileHasShebangButNotExecutable(..) => "NPV-146",
             Self::TopLevelPackageMovedOutOfByName(..) => "NPV-160",
             Self::TopLevelPackageMovedOutOfByNameWithCustomArguments(..) => "NPV-161",
             Self::NewTopLevelPackageShouldBeByName(..) => "NPV-162",
@@ -208,6 +218,8 @@ impl fmt::Display for Problem {
             Self::PackageInWrongShard(inner) => inner.fmt(f),
             Self::PackageNixMissing(inner) => inner.fmt(f),
             Self::PackageNixIsNotFile(inner) => inner.fmt(f),
+            Self::NixFileIsExecutableWithoutShebang(inner) => inner.fmt(f),
+            Self::NixFileHasShebangButNotExecutable(inner) => inner.fmt(f),
             Self::TopLevelPackageMovedOutOfByName(inner) => inner.fmt(f),
             Self::TopLevelPackageMovedOutOfByNameWithCustomArguments(inner) => inner.fmt(f),
             Self::NewTopLevelPackageShouldBeByName(inner) => inner.fmt(f),

--- a/src/problem/npv_145.rs
+++ b/src/problem/npv_145.rs
@@ -1,0 +1,20 @@
+use std::fmt;
+
+use derive_new::new;
+use relative_path::RelativePathBuf;
+
+#[derive(Clone, new)]
+pub struct NixFileIsExecutableWithoutShebang {
+    #[new(into)]
+    relative_path: RelativePathBuf,
+}
+
+impl fmt::Display for NixFileIsExecutableWithoutShebang {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { relative_path } = self;
+        write!(
+            f,
+            "- {relative_path}: Nix files must not be executable unless they have a shebang (`#!`) line.",
+        )
+    }
+}

--- a/src/problem/npv_146.rs
+++ b/src/problem/npv_146.rs
@@ -1,0 +1,20 @@
+use std::fmt;
+
+use derive_new::new;
+use relative_path::RelativePathBuf;
+
+#[derive(Clone, new)]
+pub struct NixFileHasShebangButNotExecutable {
+    #[new(into)]
+    relative_path: RelativePathBuf,
+}
+
+impl fmt::Display for NixFileHasShebangButNotExecutable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { relative_path } = self;
+        write!(
+            f,
+            "- {relative_path}: Nix files with a shebang (`#!`) line must be executable.",
+        )
+    }
+}

--- a/tests/nix-file-executable/expected
+++ b/tests/nix-file-executable/expected
@@ -1,0 +1,2 @@
+- pkgs/by-name/fo/foo/package.nix: Nix files must not be executable unless they have a shebang (`#!`) line. (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-145)
+This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/nix-file-executable/main/default.nix
+++ b/tests/nix-file-executable/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/nix-file-executable/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/nix-file-executable/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv

--- a/tests/nix-file-shebang-executable/expected
+++ b/tests/nix-file-shebang-executable/expected
@@ -1,0 +1,1 @@
+Validated successfully

--- a/tests/nix-file-shebang-executable/main/default.nix
+++ b/tests/nix-file-shebang-executable/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/nix-file-shebang-executable/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/nix-file-shebang-executable/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,2 @@
+#!/usr/bin/env nix-shell
+{ someDrv }: someDrv

--- a/tests/nix-file-shebang-not-executable/expected
+++ b/tests/nix-file-shebang-not-executable/expected
@@ -1,0 +1,2 @@
+- pkgs/by-name/fo/foo/package.nix: Nix files with a shebang (`#!`) line must be executable. (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-146)
+This PR introduces the problems listed above. Please fix them before merging, otherwise the base branch would break.

--- a/tests/nix-file-shebang-not-executable/main/default.nix
+++ b/tests/nix-file-shebang-not-executable/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/nix-file-shebang-not-executable/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/nix-file-shebang-not-executable/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,2 @@
+#!/usr/bin/env nix-shell
+{ someDrv }: someDrv


### PR DESCRIPTION
## Summary

- Adds NPV-145: detects `.nix` files with the executable bit set that lack a shebang (`#!`) line
- This is a non-ratchet (hard error) check applied to all `.nix` files in nixpkgs
- Wiki updated with [NPV-145](https://github.com/NixOS/nixpkgs-vet/wiki/NPV-145) page

Closes NixOS/nixpkgs-vet#110

## Test plan

- [x] New test case `nix-file-executable` with an executable `package.nix` (no shebang) verifies the error is reported
- [x] All existing tests continue to pass
- [x] `cargo fmt -- --check` passes