### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
@@ -81,9 +81,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -336,9 +336,9 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -641,9 +641,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 rnix = "0.14.0"
 regex = "1.12.3"
-clap = { version = "4.5.58", features = ["derive"] }
+clap = { version = "4.5.60", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.25.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre946843.ac055f38c798/nixexprs.tar.xz",
-      "hash": "sha256-erxy9meNKMaKpKQpl8KfhZsVY4EtR4eaHT94jY98Ty0="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre948338.bcc4a9d9533c/nixexprs.tar.xz",
+      "hash": "sha256-V/p5M4cAMbu/MJBDn5YABy5QJgCFpsgrnXVVc2Uo5+k="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/9xhn4iisqcagw3151mzw0rfm2am4g01l-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.58  4.5.60     4.5.60 4.5.60 
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.92.0 compatible versions
note: Re-run with `--verbose` to show more dependencies
  latest: 17 packages

```
### cargo update

```
    Updating crates.io index
     Locking 4 packages to latest Rust 1.92.0 compatible versions
    Updating anyhow v1.0.101 -> v1.0.102
    Updating linux-raw-sys v0.11.0 -> v0.12.1
    Updating rustix v1.1.3 -> v1.1.4
    Updating syn v2.0.116 -> v2.0.117

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 926 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (100 crate dependencies)

```
</details>
Running /nix/store/6mw5rifwbxian482m1v0cr9m4y9h6crz-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.82.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.82.0
    cli | 2026/02/23 15:07:40 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/02/23 15:07:44 INFO Starting job processing
updater | 2026/02/23 15:07:44 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/02/23 15:07:44 INFO Base commit SHA: 3733c9a6d306d2e09ad21d1ed0b1b4f8eec6af3e
updater | 2026/02/23 15:07:44 INFO Finished job processing
updater | 2026/02/23 15:07:44 INFO Starting job processing
updater | 2026/02/23 15:07:57 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/02/23 15:07:57 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/02/23 15:07:57 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/02/23 15:07:57 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon.rb:252:in 'Excon.get'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:193:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:164:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:34:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:374:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:231:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:07:57 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/02/23 15:07:57 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/02/23 15:08:34 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/02/23 15:08:34 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/02/23 15:08:34 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/02/23 15:08:34 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:125:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:112:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/02/23 15:08:34 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/02/23 15:08:34 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/02/23 15:09:08 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/02/23 15:09:08 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/rxwqsqiza85kpf7flibafncxv5vv38ds-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre946843.ac055f38c798/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre948338.bcc4a9d9533c/nixexprs.tar.xz
-    hash: sha256-erxy9meNKMaKpKQpl8KfhZsVY4EtR4eaHT94jY98Ty0=
+    hash: sha256-V/p5M4cAMbu/MJBDn5YABy5QJgCFpsgrnXVVc2Uo5+k=
[INFO ] Update successful.
```
</details>
