### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rnix = "0.14.0"
 regex = "1.12.3"
 clap = { version = "4.5.60", features = ["derive"] }
 serde_json = "1.0.149"
-tempfile = "3.25.0"
+tempfile = "3.26.0"
 serde = { version = "1.0.228", features = ["derive"] }
 anyhow = "1.0"
 colored = "3.1.1"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre948338.bcc4a9d9533c/nixexprs.tar.xz",
-      "hash": "sha256-V/p5M4cAMbu/MJBDn5YABy5QJgCFpsgrnXVVc2Uo5+k="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre956909.93178f6a00c2/nixexprs.tar.xz",
+      "hash": "sha256-xAHiI07j8nMZuA53r40AoWgYH9bKCgaVowNq5MpkE3g="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/9xhn4iisqcagw3151mzw0rfm2am4g01l-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name     old req compatible latest new req
====     ======= ========== ====== =======
tempfile 3.25.0  3.26.0     3.26.0 3.26.0 
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.92.0 compatible versions
note: Re-run with `--verbose` to show more dependencies
  latest: 17 packages

```
### cargo update

```
    Updating crates.io index
     Locking 1 package to latest Rust 1.92.0 compatible version
    Updating regex-syntax v0.8.9 -> v0.8.10

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 939 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (100 crate dependencies)

```
</details>
Running /nix/store/g851ysjl0al4745idks79j4ifk2x9g79-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.82.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.82.0
    cli | 2026/03/02 15:02:40 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/03/02 15:02:43 INFO Starting job processing
updater | 2026/03/02 15:02:43 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/03/02 15:02:43 INFO Base commit SHA: c8b09ffd02d46372600303ffe0a5fb4d125ea91d
updater | 2026/03/02 15:02:43 INFO Finished job processing
updater | 2026/03/02 15:02:43 INFO Starting job processing
updater | 2026/03/02 15:02:56 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/03/02 15:02:56 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/03/02 15:02:56 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/03/02 15:02:56 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon.rb:252:in 'Excon.get'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:193:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:164:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:34:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:374:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:231:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:02:56 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/03/02 15:02:56 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/03/02 15:03:29 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/03/02 15:03:29 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/03/02 15:03:29 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/03/02 15:03:29 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:125:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:112:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/03/02 15:03:29 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/03/02 15:03:29 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/03/02 15:04:01 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/03/02 15:04:01 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/ivz95rqjrdy2r8psfcqz1ggzfbc9qqfb-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre948338.bcc4a9d9533c/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre956909.93178f6a00c2/nixexprs.tar.xz
-    hash: sha256-V/p5M4cAMbu/MJBDn5YABy5QJgCFpsgrnXVVc2Uo5+k=
+    hash: sha256-xAHiI07j8nMZuA53r40AoWgYH9bKCgaVowNq5MpkE3g=
[INFO ] Update successful.
```
</details>
