### PR TITLE
Add ratchet checks for `__structuredAttrs` and `strictDeps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,7 @@ The current ratchets are:
   (see [nix evaluation checks](#nix-evaluation-checks)) must not be introduced.
 - New top-level packages defined using `pkgs.callPackage` must be defined with a package directory.
   - Once a top-level package uses `pkgs/by-name`, it also can't be moved back out of it.
+- New top-level packages must evaluate with `strictDeps = true`.
+  - Once a top-level package evaluates with `strictDeps = true`, it also can't regress to `false`.
 - New top-level packages must evaluate with `__structuredAttrs = true`.
   - Once a top-level package evaluates with `__structuredAttrs = true`, it also can't regress to `false`.

--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ The current ratchets are:
   (see [nix evaluation checks](#nix-evaluation-checks)) must not be introduced.
 - New top-level packages defined using `pkgs.callPackage` must be defined with a package directory.
   - Once a top-level package uses `pkgs/by-name`, it also can't be moved back out of it.
+- New top-level packages must evaluate with `__structuredAttrs = true`.
+  - Once a top-level package evaluates with `__structuredAttrs = true`, it also can't regress to `false`.

--- a/src/eval.nix
+++ b/src/eval.nix
@@ -60,6 +60,7 @@ let
         {
           AttributeSet = {
             is_derivation = pkgs.lib.isDerivation value;
+            strict_deps = value.strictDeps or false;
             structured_attrs = value.__structuredAttrs or false;
             definition_variant =
               if !value ? _callPackageVariant then

--- a/src/eval.nix
+++ b/src/eval.nix
@@ -60,6 +60,7 @@ let
         {
           AttributeSet = {
             is_derivation = pkgs.lib.isDerivation value;
+            structured_attrs = value.__structuredAttrs or false;
             definition_variant =
               if !value ? _callPackageVariant then
                 { ManualDefinition.is_semantic_call_package = false; }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -455,12 +455,8 @@ fn handle_non_by_name_attribute(
     use NonByNameAttribute::EvalSuccess;
     use ratchet::RatchetState::{Loose, NonApplicable, Tight};
 
-    // The ratchet state whether this attribute uses `pkgs/by-name`.
-    //
-    // This is never `Tight`, because we only either:
-    // - Know that the attribute _could_ be migrated to `pkgs/by-name`, which is `Loose`
-    // - Or we're unsure, in which case we use `NonApplicable`
-    let uses_by_name =
+    // The ratchet state for this package.
+    let package = match non_by_name_attribute {
         // This is a big ol' match on various properties of the attribute
         //
         // First, it needs to succeed evaluation. We can't know whether an attribute could be
@@ -477,107 +473,120 @@ fn handle_non_by_name_attribute(
         // `pkgs/by-name` has the problem that if a package evaluation gets broken temporarily,
         // fixing it requires a move to pkgs/by-name, which could happen more often and isn't
         // really justified.
-        if let EvalSuccess(AttributeInfo {
+        EvalSuccess(AttributeInfo {
             // We're only interested in attributes that are attribute sets, which all derivations
             // are. Anything else can't be in `pkgs/by-name`.
-            attribute_variant: AttributeVariant::AttributeSet {
-                // As of today, non-derivation attribute sets can't be in `pkgs/by-name`.
-                is_derivation: true,
-                // Of the two definition variants, really only the manual one makes sense here.
-                //
-                // Special cases are:
-                //
-                // - Manual aliases to auto-called packages are not treated as manual definitions,
-                //   due to limitations in the semantic `callPackage` detection.
-                //   So those should be ignored.
-                //
-                // - Manual definitions using the internal `_internalCallByNamePackageFile` are
-                //   not treated as manual definitions, since `_internalCallByNamePackageFile` is
-                //   used to detect automatic ones. We can't distinguish from the above case, so we
-                //   just need to ignore this one too, even if that internal attribute should never
-                //   be called manually.
-                definition_variant: DefinitionVariant::ManualDefinition {
-                    is_semantic_call_package
-                }
-            },
+            attribute_variant:
+                AttributeVariant::AttributeSet {
+                    // As of today, non-derivation attribute sets can't be in `pkgs/by-name`.
+                    is_derivation: true,
+                    // Of the two definition variants, really only the manual one makes sense
+                    // here.
+                    //
+                    // Special cases are:
+                    //
+                    // - Manual aliases to auto-called packages are not treated as manual
+                    //   definitions, due to limitations in the semantic `callPackage` detection.
+                    //   So those should be ignored.
+                    //
+                    // - Manual definitions using the internal `_internalCallByNamePackageFile`
+                    //   are not treated as manual definitions, since
+                    //   `_internalCallByNamePackageFile` is used to detect automatic ones. We
+                    //   can't distinguish from the above case, so we just need to ignore this one
+                    //   too, even if that internal attribute should never be called manually.
+                    definition_variant,
+                },
+            location,
+        }) => {
             // We need the location of the manual definition, because otherwise we can't figure out
             // whether it's a syntactic `callPackage`.
-            location: Some(location),
-        }) = non_by_name_attribute {
+            let parsed_definition = if let Some(location) = location {
+                // Parse the Nix file in the location
+                let nix_file = nix_file_store.get(&location.file)?;
 
-        // Parse the Nix file in the location
-        let nix_file = nix_file_store.get(&location.file)?;
+                // The relative location of the Nix file, for error messages
+                let location = location.relative(nixpkgs_path).with_context(|| {
+                    format!(
+                        "Failed to resolve the file where attribute {attribute_name} is defined"
+                    )
+                })?;
 
-        // The relative location of the Nix file, for error messages
-        let location = location.relative(nixpkgs_path).with_context(|| {
-            format!("Failed to resolve the file where attribute {attribute_name} is defined")
-        })?;
+                // Figure out whether it's an attribute definition of the form
+                // `= callPackage <arg1> <arg2>`, returning the arguments if so.
+                let (optional_syntactic_call_package, _definition) = nix_file
+                    .call_package_argument_info_at(location.line, location.column, nixpkgs_path)
+                    .with_context(|| {
+                        format!(
+                            "Failed to get the definition info for attribute {}",
+                            attribute_name
+                        )
+                    })?;
+                Some((location, optional_syntactic_call_package))
+            } else {
+                None
+            };
 
-        // Figure out whether it's an attribute definition of the form
-        // `= callPackage <arg1> <arg2>`, returning the arguments if so.
-        let (optional_syntactic_call_package, _definition) = nix_file
-            .call_package_argument_info_at(
-                location.line,
-                location.column,
-                // Passing the Nixpkgs path here both checks that the <arg1> is within Nixpkgs,
-                // and strips the absolute Nixpkgs path from it, such that
-                // syntactic_call_package.relative_path is relative to Nixpkgs
-                nixpkgs_path
-            )
-            .with_context(|| {
-                format!("Failed to get the definition info for attribute {}", attribute_name)
-            })?;
-
-        // At this point, we completed two different checks for whether it's a `callPackage`.
-        match (is_semantic_call_package, optional_syntactic_call_package) {
-            // Something like `<attr> = { }`
-            (false, None)
-            // Something like `<attr> = pythonPackages.callPackage ...`
-            | (false, Some(_))
-            // Something like `<attr> = bar` where `bar = pkgs.callPackage ...`
-            | (true, None) => {
-                // In all of these cases, it's not possible to migrate the package to
-                // `pkgs/by-name`.
+            // This is never `Tight`, because we only either:
+            // - Know that the attribute _could_ be migrated to `pkgs/by-name`, which is `Loose`
+            // - Or we're unsure, in which case we use `NonApplicable`
+            let uses_by_name = if let (
+                DefinitionVariant::ManualDefinition {
+                    is_semantic_call_package,
+                },
+                Some((location, optional_syntactic_call_package)),
+            ) = (definition_variant, parsed_definition.as_ref())
+            {
+                // At this point, we completed two different checks for whether it's a
+                // `callPackage`.
+                match (is_semantic_call_package, optional_syntactic_call_package.as_ref()) {
+                        // Something like `<attr> = { }`
+                        (false, None)
+                        // Something like `<attr> = pythonPackages.callPackage ...`
+                        | (false, Some(_))
+                    // Something like `<attr> = bar` where `bar = pkgs.callPackage ...`
+                    | (true, None) => NonApplicable,
+                    // Something like `<attr> = pkgs.callPackage ...`
+                    (true, Some(syntactic_call_package)) => {
+                        // It's only possible to migrate such definitions if..
+                        match syntactic_call_package.relative_path {
+                            Some(ref rel_path) if rel_path.starts_with(BASE_SUBPATH) => {
+                                // ..the path is not already within `pkgs/by-name` like
+                                //
+                                //   foo-variant = callPackage ../by-name/fo/foo/package.nix {
+                                //     someFlag = true;
+                                //   }
+                                //
+                                // While such definitions could be moved to `pkgs/by-name` by
+                                // using `.override { someFlag = true; }` instead, this changes
+                                // the semantics in relation with overlays, so migration is
+                                // generally not possible.
+                                //
+                                // See also "package variants" in RFC 140:
+                                // https://github.com/NixOS/rfcs/blob/master/rfcs/0140-simple-package-paths.md#package-variants
+                                NonApplicable
+                            }
+                            _ => Loose((syntactic_call_package.clone(), location.file.clone())),
+                            }
+                        }
+                    }
+            } else {
                 NonApplicable
-            }
+            };
 
-            // Something like `<attr> = pkgs.callPackage ...`
-            (true, Some(syntactic_call_package)) => {
-                // It's only possible to migrate such a definitions if..
-                match syntactic_call_package.relative_path {
-                    Some(ref rel_path) if rel_path.starts_with(BASE_SUBPATH) => {
-                        // ..the path is not already within `pkgs/by-name` like
-                        //
-                        //   foo-variant = callPackage ../by-name/fo/foo/package.nix {
-                        //     someFlag = true;
-                        //   }
-                        //
-                        // While such definitions could be moved to `pkgs/by-name` by using
-                        // `.override { someFlag = true; }` instead, this changes the semantics in
-                        // relation with overlays, so migration is generally not possible.
-                        //
-                        // See also "package variants" in RFC 140:
-                        // https://github.com/NixOS/rfcs/blob/master/rfcs/0140-simple-package-paths.md#package-variants
-                        NonApplicable
-                    }
-                    _ => {
-                        // Otherwise, the path is outside `pkgs/by-name`, which means it can be
-                        // migrated.
-                        Loose((syntactic_call_package, location.file))
-                    }
-                }
+            ratchet::Package {
+                // Packages being checked in this function _always_ need a manual definition,
+                // because they're not using `pkgs/by-name` which would allow avoiding it. So the
+                // ratchet stays `Tight` regardless of the other checks in this function.
+                manual_definition: Tight,
+                uses_by_name,
             }
         }
-    } else {
-        // This catches all the cases not matched by the above `if let`, falling back to not being
-        // able to migrate such attributes.
-        NonApplicable
+        // This catches all the cases not matched by the above `EvalSuccess`, falling back to not
+        // being able to make any good calls about the ratchet state.
+        _ => ratchet::Package {
+            manual_definition: Tight,
+            uses_by_name: NonApplicable,
+        },
     };
-    Ok(Success(ratchet::Package {
-        // Packages being checked in this function _always_ need a manual definition, because
-        // they're not using `pkgs/by-name` which would allow avoiding it. So instead of repeating
-        // ourselves all the time to define `manual_definition`, just set it once at the end here.
-        manual_definition: Tight,
-        uses_by_name,
-    }))
+    Ok(Success(package))
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -81,6 +81,8 @@ pub enum AttributeVariant {
     AttributeSet {
         /// Whether the attribute is a derivation (`lib.isDerivation`)
         is_derivation: bool,
+        /// Whether the attribute evaluates with `__structuredAttrs = true`.
+        structured_attrs: bool,
         /// The type of `callPackage` used.
         definition_variant: DefinitionVariant,
     },
@@ -298,6 +300,7 @@ fn by_name(
             attribute_variant:
                 AttributeVariant::AttributeSet {
                     is_derivation,
+                    structured_attrs,
                     definition_variant,
                 },
             location,
@@ -373,18 +376,26 @@ fn by_name(
 
             // Independently report problems about whether it's a derivation and the callPackage
             // variant.
-            is_derivation_result.and_(variant_result)
+            is_derivation_result
+                .and_(variant_result)
+                .map(|manual_definition| ratchet::Package {
+                    manual_definition,
+                    uses_by_name: Tight,
+                    structured_attrs: enabled_attribute_ratchet(
+                        structured_attrs,
+                        structure::relative_file_for_package(attribute_name),
+                    ),
+                })
         }
     };
-    Ok(
-        // Packages being checked in this function are _always_ already defined in `pkgs/by-name`,
-        // so instead of repeating ourselves all the time to define `uses_by_name`, just set it
-        // once at the end with a map.
-        manual_definition_result.map(|manual_definition| ratchet::Package {
-            manual_definition,
-            uses_by_name: Tight,
-        }),
-    )
+    Ok(manual_definition_result)
+}
+
+fn enabled_attribute_ratchet<R>(enabled: bool, file: RelativePathBuf) -> ratchet::RatchetState<R>
+where
+    R: ratchet::ToProblem<ToContext = RelativePathBuf>,
+{
+    if enabled { Tight } else { Loose(file) }
 }
 
 /// Handles the case for packages in `pkgs/by-name` that are manually overridden,
@@ -480,6 +491,7 @@ fn handle_non_by_name_attribute(
                 AttributeVariant::AttributeSet {
                     // As of today, non-derivation attribute sets can't be in `pkgs/by-name`.
                     is_derivation: true,
+                    structured_attrs,
                     // Of the two definition variants, really only the manual one makes sense
                     // here.
                     //
@@ -573,12 +585,31 @@ fn handle_non_by_name_attribute(
                 NonApplicable
             };
 
+            // For evaluated boolean ratchets, point at the package file when we can resolve one.
+            // Otherwise fall back to the file that defines the top-level attribute.
+            let evaluated_attribute_file =
+                parsed_definition
+                    .as_ref()
+                    .map(|(location, optional_syntactic_call_package)| {
+                        optional_syntactic_call_package
+                            .as_ref()
+                            .and_then(|call_package| call_package.relative_path.clone())
+                            .unwrap_or_else(|| location.file.clone())
+                    });
+
+            let structured_attrs = match (structured_attrs, evaluated_attribute_file) {
+                (true, _) => Tight,
+                (false, Some(file)) => Loose(file),
+                (false, None) => NonApplicable,
+            };
+
             ratchet::Package {
                 // Packages being checked in this function _always_ need a manual definition,
                 // because they're not using `pkgs/by-name` which would allow avoiding it. So the
                 // ratchet stays `Tight` regardless of the other checks in this function.
                 manual_definition: Tight,
                 uses_by_name,
+                structured_attrs,
             }
         }
         // This catches all the cases not matched by the above `EvalSuccess`, falling back to not
@@ -586,6 +617,7 @@ fn handle_non_by_name_attribute(
         _ => ratchet::Package {
             manual_definition: Tight,
             uses_by_name: NonApplicable,
+            structured_attrs: NonApplicable,
         },
     };
     Ok(Success(package))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -81,6 +81,8 @@ pub enum AttributeVariant {
     AttributeSet {
         /// Whether the attribute is a derivation (`lib.isDerivation`)
         is_derivation: bool,
+        /// Whether the attribute evaluates with `strictDeps = true`.
+        strict_deps: bool,
         /// Whether the attribute evaluates with `__structuredAttrs = true`.
         structured_attrs: bool,
         /// The type of `callPackage` used.
@@ -300,6 +302,7 @@ fn by_name(
             attribute_variant:
                 AttributeVariant::AttributeSet {
                     is_derivation,
+                    strict_deps,
                     structured_attrs,
                     definition_variant,
                 },
@@ -381,6 +384,10 @@ fn by_name(
                 .map(|manual_definition| ratchet::Package {
                     manual_definition,
                     uses_by_name: Tight,
+                    strict_deps: enabled_attribute_ratchet(
+                        strict_deps,
+                        structure::relative_file_for_package(attribute_name),
+                    ),
                     structured_attrs: enabled_attribute_ratchet(
                         structured_attrs,
                         structure::relative_file_for_package(attribute_name),
@@ -491,6 +498,7 @@ fn handle_non_by_name_attribute(
                 AttributeVariant::AttributeSet {
                     // As of today, non-derivation attribute sets can't be in `pkgs/by-name`.
                     is_derivation: true,
+                    strict_deps,
                     structured_attrs,
                     // Of the two definition variants, really only the manual one makes sense
                     // here.
@@ -597,6 +605,12 @@ fn handle_non_by_name_attribute(
                             .unwrap_or_else(|| location.file.clone())
                     });
 
+            let strict_deps = match (strict_deps, evaluated_attribute_file.clone()) {
+                (true, _) => Tight,
+                (false, Some(file)) => Loose(file),
+                (false, None) => NonApplicable,
+            };
+
             let structured_attrs = match (structured_attrs, evaluated_attribute_file) {
                 (true, _) => Tight,
                 (false, Some(file)) => Loose(file),
@@ -609,6 +623,7 @@ fn handle_non_by_name_attribute(
                 // ratchet stays `Tight` regardless of the other checks in this function.
                 manual_definition: Tight,
                 uses_by_name,
+                strict_deps,
                 structured_attrs,
             }
         }
@@ -617,6 +632,7 @@ fn handle_non_by_name_attribute(
         _ => ratchet::Package {
             manual_definition: Tight,
             uses_by_name: NonApplicable,
+            strict_deps: NonApplicable,
             structured_attrs: NonApplicable,
         },
     };

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -78,7 +78,7 @@ impl NixFile {
 }
 
 /// Information about `callPackage` arguments.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CallPackageArgumentInfo {
     /// The relative path of the first argument, or `None` if it's not a path.
     pub relative_path: Option<RelativePathBuf>,

--- a/src/problem/mod.rs
+++ b/src/problem/mod.rs
@@ -36,6 +36,8 @@ pub mod npv_160;
 pub mod npv_161;
 pub mod npv_162;
 pub mod npv_163;
+pub mod npv_164;
+pub mod npv_165;
 pub mod npv_166;
 pub mod npv_167;
 
@@ -137,6 +139,12 @@ pub enum Problem {
         npv_163::NewTopLevelPackageShouldBeByNameWithCustomArgument,
     ),
 
+    /// NPV-164: new top-level package must enable strictDeps
+    NewTopLevelPackageMustEnableStrictDeps(npv_164::NewTopLevelPackageMustEnableStrictDeps),
+
+    /// NPV-165: top-level package disabled strictDeps
+    TopLevelPackageDisabledStrictDeps(npv_165::TopLevelPackageDisabledStrictDeps),
+
     /// NPV-166: new top-level package must enable __structuredAttrs
     NewTopLevelPackageMustEnableStructuredAttrs(
         npv_166::NewTopLevelPackageMustEnableStructuredAttrs,
@@ -180,6 +188,8 @@ impl Problem {
             Self::TopLevelPackageMovedOutOfByNameWithCustomArguments(..) => "NPV-161",
             Self::NewTopLevelPackageShouldBeByName(..) => "NPV-162",
             Self::NewTopLevelPackageShouldBeByNameWithCustomArgument(..) => "NPV-163",
+            Self::NewTopLevelPackageMustEnableStrictDeps(..) => "NPV-164",
+            Self::TopLevelPackageDisabledStrictDeps(..) => "NPV-165",
             Self::NewTopLevelPackageMustEnableStructuredAttrs(..) => "NPV-166",
             Self::TopLevelPackageDisabledStructuredAttrs(..) => "NPV-167",
         }
@@ -224,6 +234,8 @@ impl fmt::Display for Problem {
             Self::TopLevelPackageMovedOutOfByNameWithCustomArguments(inner) => inner.fmt(f),
             Self::NewTopLevelPackageShouldBeByName(inner) => inner.fmt(f),
             Self::NewTopLevelPackageShouldBeByNameWithCustomArgument(inner) => inner.fmt(f),
+            Self::NewTopLevelPackageMustEnableStrictDeps(inner) => inner.fmt(f),
+            Self::TopLevelPackageDisabledStrictDeps(inner) => inner.fmt(f),
             Self::NewTopLevelPackageMustEnableStructuredAttrs(inner) => inner.fmt(f),
             Self::TopLevelPackageDisabledStructuredAttrs(inner) => inner.fmt(f),
         }

--- a/src/problem/mod.rs
+++ b/src/problem/mod.rs
@@ -36,6 +36,8 @@ pub mod npv_160;
 pub mod npv_161;
 pub mod npv_162;
 pub mod npv_163;
+pub mod npv_166;
+pub mod npv_167;
 
 const WIKI_BASE_URL: &str = "https://github.com/NixOS/nixpkgs-vet/wiki";
 
@@ -134,6 +136,14 @@ pub enum Problem {
     NewTopLevelPackageShouldBeByNameWithCustomArgument(
         npv_163::NewTopLevelPackageShouldBeByNameWithCustomArgument,
     ),
+
+    /// NPV-166: new top-level package must enable __structuredAttrs
+    NewTopLevelPackageMustEnableStructuredAttrs(
+        npv_166::NewTopLevelPackageMustEnableStructuredAttrs,
+    ),
+
+    /// NPV-167: top-level package disabled __structuredAttrs
+    TopLevelPackageDisabledStructuredAttrs(npv_167::TopLevelPackageDisabledStructuredAttrs),
 }
 
 impl Problem {
@@ -170,6 +180,8 @@ impl Problem {
             Self::TopLevelPackageMovedOutOfByNameWithCustomArguments(..) => "NPV-161",
             Self::NewTopLevelPackageShouldBeByName(..) => "NPV-162",
             Self::NewTopLevelPackageShouldBeByNameWithCustomArgument(..) => "NPV-163",
+            Self::NewTopLevelPackageMustEnableStructuredAttrs(..) => "NPV-166",
+            Self::TopLevelPackageDisabledStructuredAttrs(..) => "NPV-167",
         }
     }
 
@@ -212,6 +224,8 @@ impl fmt::Display for Problem {
             Self::TopLevelPackageMovedOutOfByNameWithCustomArguments(inner) => inner.fmt(f),
             Self::NewTopLevelPackageShouldBeByName(inner) => inner.fmt(f),
             Self::NewTopLevelPackageShouldBeByNameWithCustomArgument(inner) => inner.fmt(f),
+            Self::NewTopLevelPackageMustEnableStructuredAttrs(inner) => inner.fmt(f),
+            Self::TopLevelPackageDisabledStructuredAttrs(inner) => inner.fmt(f),
         }
     }
 }

--- a/src/problem/npv_164.rs
+++ b/src/problem/npv_164.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+use derive_new::new;
+use indoc::writedoc;
+use relative_path::RelativePathBuf;
+
+#[derive(Clone, new)]
+pub struct NewTopLevelPackageMustEnableStrictDeps {
+    #[new(into)]
+    package_name: String,
+    #[new(into)]
+    file: RelativePathBuf,
+}
+
+impl fmt::Display for NewTopLevelPackageMustEnableStrictDeps {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { package_name, file } = self;
+        writedoc!(
+            f,
+            "
+            - Attribute `pkgs.{package_name}` is a new package with `strictDeps` unset or set to `false`.
+              Please enable `strictDeps = true;` in {file}.
+            ",
+        )
+    }
+}

--- a/src/problem/npv_165.rs
+++ b/src/problem/npv_165.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+use derive_new::new;
+use indoc::writedoc;
+use relative_path::RelativePathBuf;
+
+#[derive(Clone, new)]
+pub struct TopLevelPackageDisabledStrictDeps {
+    #[new(into)]
+    package_name: String,
+    #[new(into)]
+    file: RelativePathBuf,
+}
+
+impl fmt::Display for TopLevelPackageDisabledStrictDeps {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { package_name, file } = self;
+        writedoc!(
+            f,
+            "
+            - Attribute `pkgs.{package_name}` previously evaluated with `strictDeps = true`, but now evaluates with `strictDeps = false`.
+              Please re-enable `strictDeps = true;` in {file}.
+            ",
+        )
+    }
+}

--- a/src/problem/npv_166.rs
+++ b/src/problem/npv_166.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+use derive_new::new;
+use indoc::writedoc;
+use relative_path::RelativePathBuf;
+
+#[derive(Clone, new)]
+pub struct NewTopLevelPackageMustEnableStructuredAttrs {
+    #[new(into)]
+    package_name: String,
+    #[new(into)]
+    file: RelativePathBuf,
+}
+
+impl fmt::Display for NewTopLevelPackageMustEnableStructuredAttrs {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { package_name, file } = self;
+        writedoc!(
+            f,
+            "
+            - Attribute `pkgs.{package_name}` is a new package with `__structuredAttrs` unset or set to `false`.
+              Please enable `__structuredAttrs = true;` in {file}.
+            ",
+        )
+    }
+}

--- a/src/problem/npv_167.rs
+++ b/src/problem/npv_167.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+use derive_new::new;
+use indoc::writedoc;
+use relative_path::RelativePathBuf;
+
+#[derive(Clone, new)]
+pub struct TopLevelPackageDisabledStructuredAttrs {
+    #[new(into)]
+    package_name: String,
+    #[new(into)]
+    file: RelativePathBuf,
+}
+
+impl fmt::Display for TopLevelPackageDisabledStructuredAttrs {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { package_name, file } = self;
+        writedoc!(
+            f,
+            "
+            - Attribute `pkgs.{package_name}` previously evaluated with `__structuredAttrs = true`, but now evaluates with `__structuredAttrs = false`.
+              Please re-enable `__structuredAttrs = true;` in {file}.
+            ",
+        )
+    }
+}

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use relative_path::RelativePathBuf;
 
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::problem::{Problem, npv_160, npv_161, npv_162, npv_163};
+use crate::problem::{Problem, npv_160, npv_161, npv_162, npv_163, npv_166, npv_167};
 use crate::validation::{self, Validation, Validation::Success};
 
 /// The ratchet value for the entirety of Nixpkgs.
@@ -44,6 +44,9 @@ pub struct Package {
 
     /// The ratchet value for the check for new packages using pkgs/by-name
     pub uses_by_name: RatchetState<UsesByName>,
+
+    /// The ratchet value for the check for enabling `__structuredAttrs`.
+    pub structured_attrs: RatchetState<StructuredAttrs>,
 }
 
 impl Package {
@@ -59,6 +62,11 @@ impl Package {
                 name,
                 optional_from.map(|x| &x.uses_by_name),
                 &to.uses_by_name,
+            ),
+            RatchetState::<StructuredAttrs>::compare(
+                name,
+                optional_from.map(|x| &x.structured_attrs),
+                &to.structured_attrs,
             ),
         ])
     }
@@ -212,5 +220,24 @@ impl<ProblemKind: EnabledAttributeProblem> ToProblem for EnabledAttribute<Proble
         } else {
             ProblemKind::introduced_problem(name, file.clone())
         }
+    }
+}
+
+/// The ratchet value of an attribute for enabling `__structuredAttrs`.
+///
+/// New packages must evaluate with `__structuredAttrs = true` unless their package set already
+/// makes that the default. Once a package evaluates with `__structuredAttrs = true`, it must not
+/// regress.
+pub type StructuredAttrs = EnabledAttribute<StructuredAttrsProblem>;
+
+pub enum StructuredAttrsProblem {}
+
+impl EnabledAttributeProblem for StructuredAttrsProblem {
+    fn introduced_problem(name: &str, file: RelativePathBuf) -> Problem {
+        npv_166::NewTopLevelPackageMustEnableStructuredAttrs::new(name, file).into()
+    }
+
+    fn regressed_problem(name: &str, file: RelativePathBuf) -> Problem {
+        npv_167::TopLevelPackageDisabledStructuredAttrs::new(name, file).into()
     }
 }

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -10,7 +10,9 @@ use std::collections::BTreeMap;
 use relative_path::RelativePathBuf;
 
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::problem::{Problem, npv_160, npv_161, npv_162, npv_163, npv_166, npv_167};
+use crate::problem::{
+    Problem, npv_160, npv_161, npv_162, npv_163, npv_164, npv_165, npv_166, npv_167,
+};
 use crate::validation::{self, Validation, Validation::Success};
 
 /// The ratchet value for the entirety of Nixpkgs.
@@ -45,6 +47,9 @@ pub struct Package {
     /// The ratchet value for the check for new packages using pkgs/by-name
     pub uses_by_name: RatchetState<UsesByName>,
 
+    /// The ratchet value for the check for enabling `strictDeps`.
+    pub strict_deps: RatchetState<StrictDeps>,
+
     /// The ratchet value for the check for enabling `__structuredAttrs`.
     pub structured_attrs: RatchetState<StructuredAttrs>,
 }
@@ -62,6 +67,11 @@ impl Package {
                 name,
                 optional_from.map(|x| &x.uses_by_name),
                 &to.uses_by_name,
+            ),
+            RatchetState::<StrictDeps>::compare(
+                name,
+                optional_from.map(|x| &x.strict_deps),
+                &to.strict_deps,
             ),
             RatchetState::<StructuredAttrs>::compare(
                 name,
@@ -220,6 +230,24 @@ impl<ProblemKind: EnabledAttributeProblem> ToProblem for EnabledAttribute<Proble
         } else {
             ProblemKind::introduced_problem(name, file.clone())
         }
+    }
+}
+
+/// The ratchet value of an attribute for enabling `strictDeps`.
+///
+/// New packages must evaluate with `strictDeps = true` unless their package set already makes
+/// that the default. Once a package evaluates with `strictDeps = true`, it must not regress.
+pub type StrictDeps = EnabledAttribute<StrictDepsProblem>;
+
+pub enum StrictDepsProblem {}
+
+impl EnabledAttributeProblem for StrictDepsProblem {
+    fn introduced_problem(name: &str, file: RelativePathBuf) -> Problem {
+        npv_164::NewTopLevelPackageMustEnableStrictDeps::new(name, file).into()
+    }
+
+    fn regressed_problem(name: &str, file: RelativePathBuf) -> Problem {
+        npv_165::TopLevelPackageDisabledStrictDeps::new(name, file).into()
     }
 }
 

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -2,6 +2,8 @@
 //!
 //! Each type has a `compare` method that validates the ratchet checks for that item.
 
+use std::marker::PhantomData;
+
 use relative_path::RelativePath;
 use std::collections::BTreeMap;
 
@@ -188,6 +190,27 @@ impl ToProblem for UsesByName {
                 file,
             )
             .into(),
+        }
+    }
+}
+
+pub trait EnabledAttributeProblem {
+    fn introduced_problem(name: &str, file: RelativePathBuf) -> Problem;
+    fn regressed_problem(name: &str, file: RelativePathBuf) -> Problem;
+}
+
+/// The ratchet value of an evaluated boolean attribute that must be enabled for new packages and
+/// must not regress to `false` once enabled.
+pub struct EnabledAttribute<ProblemKind>(PhantomData<ProblemKind>);
+
+impl<ProblemKind: EnabledAttributeProblem> ToProblem for EnabledAttribute<ProblemKind> {
+    type ToContext = RelativePathBuf;
+
+    fn to_problem(name: &str, optional_from: Option<()>, file: &Self::ToContext) -> Problem {
+        if optional_from.is_some() {
+            ProblemKind::regressed_problem(name, file.clone())
+        } else {
+            ProblemKind::introduced_problem(name, file.clone())
         }
     }
 }

--- a/tests/mock-nixpkgs.nix
+++ b/tests/mock-nixpkgs.nix
@@ -43,6 +43,7 @@ let
     // lib.mapAttrs (name: value: value) {
       someDrv = {
         type = "derivation";
+        strictDeps = true;
         __structuredAttrs = true;
       };
     };

--- a/tests/mock-nixpkgs.nix
+++ b/tests/mock-nixpkgs.nix
@@ -43,6 +43,7 @@ let
     // lib.mapAttrs (name: value: value) {
       someDrv = {
         type = "derivation";
+        __structuredAttrs = true;
       };
     };
 

--- a/tests/strict-deps-new-false/expected
+++ b/tests/strict-deps-new-false/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `strictDeps` unset or set to `false`.
+  Please enable `strictDeps = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-164)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/strict-deps-new-false/main/default.nix
+++ b/tests/strict-deps-new-false/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/strict-deps-new-false/main/pkgs/by-name/README.md
+++ b/tests/strict-deps-new-false/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/strict-deps-new-false/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-false/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv // { strictDeps = false; }

--- a/tests/strict-deps-new-true/expected
+++ b/tests/strict-deps-new-true/expected
@@ -1,0 +1,1 @@
+Validated successfully

--- a/tests/strict-deps-new-true/main/default.nix
+++ b/tests/strict-deps-new-true/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/strict-deps-new-true/main/pkgs/by-name/README.md
+++ b/tests/strict-deps-new-true/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/strict-deps-new-true/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-true/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv // { strictDeps = true; }

--- a/tests/strict-deps-new-unset/expected
+++ b/tests/strict-deps-new-unset/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `strictDeps` unset or set to `false`.
+  Please enable `strictDeps = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-164)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/strict-deps-new-unset/main/default.nix
+++ b/tests/strict-deps-new-unset/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/strict-deps-new-unset/main/pkgs/by-name/README.md
+++ b/tests/strict-deps-new-unset/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/strict-deps-new-unset/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-unset/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: removeAttrs someDrv [ "strictDeps" ]

--- a/tests/strict-deps-regression/base/default.nix
+++ b/tests/strict-deps-regression/base/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/strict-deps-regression/base/pkgs/by-name/README.md
+++ b/tests/strict-deps-regression/base/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/strict-deps-regression/base/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-regression/base/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv

--- a/tests/strict-deps-regression/expected
+++ b/tests/strict-deps-regression/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` previously evaluated with `strictDeps = true`, but now evaluates with `strictDeps = false`.
+  Please re-enable `strictDeps = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-165)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/strict-deps-regression/main/default.nix
+++ b/tests/strict-deps-regression/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/strict-deps-regression/main/pkgs/by-name/README.md
+++ b/tests/strict-deps-regression/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/strict-deps-regression/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-regression/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv // { strictDeps = false; }

--- a/tests/structured-attrs-new-false/expected
+++ b/tests/structured-attrs-new-false/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `__structuredAttrs` unset or set to `false`.
+  Please enable `__structuredAttrs = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-166)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/structured-attrs-new-false/main/default.nix
+++ b/tests/structured-attrs-new-false/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/structured-attrs-new-false/main/pkgs/by-name/README.md
+++ b/tests/structured-attrs-new-false/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/structured-attrs-new-false/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-false/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv // { __structuredAttrs = false; }

--- a/tests/structured-attrs-new-true/expected
+++ b/tests/structured-attrs-new-true/expected
@@ -1,0 +1,1 @@
+Validated successfully

--- a/tests/structured-attrs-new-true/main/default.nix
+++ b/tests/structured-attrs-new-true/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/structured-attrs-new-true/main/pkgs/by-name/README.md
+++ b/tests/structured-attrs-new-true/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/structured-attrs-new-true/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-true/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv // { __structuredAttrs = true; }

--- a/tests/structured-attrs-new-unset/expected
+++ b/tests/structured-attrs-new-unset/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `__structuredAttrs` unset or set to `false`.
+  Please enable `__structuredAttrs = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-166)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/structured-attrs-new-unset/main/default.nix
+++ b/tests/structured-attrs-new-unset/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/structured-attrs-new-unset/main/pkgs/by-name/README.md
+++ b/tests/structured-attrs-new-unset/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/structured-attrs-new-unset/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-unset/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: removeAttrs someDrv [ "__structuredAttrs" ]

--- a/tests/structured-attrs-regression/base/default.nix
+++ b/tests/structured-attrs-regression/base/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/structured-attrs-regression/base/pkgs/by-name/README.md
+++ b/tests/structured-attrs-regression/base/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/structured-attrs-regression/base/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-regression/base/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv

--- a/tests/structured-attrs-regression/expected
+++ b/tests/structured-attrs-regression/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` previously evaluated with `__structuredAttrs = true`, but now evaluates with `__structuredAttrs = false`.
+  Please re-enable `__structuredAttrs = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-167)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/structured-attrs-regression/main/default.nix
+++ b/tests/structured-attrs-regression/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/structured-attrs-regression/main/pkgs/by-name/README.md
+++ b/tests/structured-attrs-regression/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/structured-attrs-regression/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-regression/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv // { __structuredAttrs = false; }


### PR DESCRIPTION
:warning: **Disclaimer: This changeset was developed with the help of AI.**

This adds ratchet checks for two evaluated derivation flags:

- `__structuredAttrs` must not be newly introduced in a disabled state
- `strictDeps` must not be newly introduced in a disabled state
- once either flag evaluates to enabled for a package, it must not regress

The checks are based on evaluated attribute state rather than textual matching, so they also work in package sets where
these flags are already enabled by default.

## Approach

The series first adds shared infrastructure for ratchets over evaluated boolean attributes.

It then refactors non-pkgs/by-name evaluation so later ratchets can reuse resolved definition and location information. That
keeps the feature commits focused on the new policy, instead of mixing them with evaluator reshaping.

Finally, the two concrete ratchets are added:

- `__structuredAttrs`
- `strictDeps`

Both apply to top-level package attributes, including attributes outside `pkgs/by-name` when evaluation yields enough information to make a reliable call.

## Notes

The test mock is adjusted so the default mock derivation already enables these flags. That keeps the fixture diff smaller and leaves explicit overrides only in the focused regression/new-package tests.

## Benchmark

Measured on https://github.com/NixOS/nixpkgs/commit/b11031962d37f9b731a2e721eb265887c27dbc74 with `hyperfine --warmup 1 --runs 5`:

Baseline b62136c:

```bash
Benchmark 1: target/release/nixpkgs-vet /home/tobim/n/nixpkgs --base /home/tobim/n/nixpkgs >/dev/null 2>/dev/null
  Time (mean ± σ):     19.193 s ±  0.223 s    [User: 38.135 s, System: 6.804 s]
  Range (min … max):   18.958 s … 19.490 s    5 runs
```

Current branch:

```bash
Benchmark 1: target/release/nixpkgs-vet /home/tobim/n/nixpkgs --base /home/tobim/n/nixpkgs >/dev/null 2>/dev/null
  Time (mean ± σ):     19.223 s ±  0.253 s    [User: 38.328 s, System: 6.840 s]
  Range (min … max):   18.974 s … 19.572 s    5 runs
```

Observed difference: about +0.03s / +0.16%.
