### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -330,9 +330,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -451,18 +451,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre956909.93178f6a00c2/nixexprs.tar.xz",
-      "hash": "sha256-xAHiI07j8nMZuA53r40AoWgYH9bKCgaVowNq5MpkE3g="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre960315.608d0cadfed2/nixexprs.tar.xz",
+      "hash": "sha256-ng4mTBcXO6Nc1cTlXxCPkI49nDJbwFNg/DBhx7YkymE="
     },
     "treefmt-nix": {
       "type": "Git",
@@ -15,9 +15,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "337a4fe074be1042a35086f15481d763b8ddc0e7",
-      "url": "https://github.com/numtide/treefmt-nix/archive/337a4fe074be1042a35086f15481d763b8ddc0e7.tar.gz",
-      "hash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk="
+      "revision": "3710e0e1218041bbad640352a0440114b1e10428",
+      "url": "https://github.com/numtide/treefmt-nix/archive/3710e0e1218041bbad640352a0440114b1e10428.tar.gz",
+      "hash": "sha256-IjU1FxYqm+VDe5qIOxoW+pISBlGvVApRjiw/Y/ttJzY="
     }
   },
   "version": 7


### PR DESCRIPTION
Running /nix/store/wqp8x97pcia5s7axbrcng1293sl9gasj-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 18 packages

```
### cargo update

```
    Updating crates.io index
     Locking 4 packages to latest Rust 1.93.0 compatible versions
    Updating getrandom v0.4.1 -> v0.4.2
    Updating libc v0.2.182 -> v0.2.183
    Updating quote v1.0.44 -> v1.0.45
    Updating r-efi v5.3.0 -> v6.0.0

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 946 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (100 crate dependencies)

```
</details>
Running /nix/store/nwa6xi035zdrl5icj0m9h9w3szsrfsdj-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.82.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.82.0
    cli | 2026/03/09 15:08:38 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/03/09 15:08:41 INFO Starting job processing
updater | 2026/03/09 15:08:41 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/03/09 15:08:41 INFO Base commit SHA: a3075d1e031246c23eda421b10d75f6ae6a542ee
updater | 2026/03/09 15:08:41 INFO Finished job processing
updater | 2026/03/09 15:08:41 INFO Starting job processing
updater | 2026/03/09 15:08:53 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/03/09 15:08:53 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/03/09 15:08:53 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/03/09 15:08:53 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon.rb:252:in 'Excon.get'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:193:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:164:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:34:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:374:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:231:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:08:53 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/03/09 15:08:53 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/03/09 15:09:26 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/03/09 15:09:26 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/03/09 15:09:26 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/03/09 15:09:26 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:125:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:112:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/03/09 15:09:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/03/09 15:09:26 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/03/09 15:09:57 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/03/09 15:09:57 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/3yx5dnhy62vd1cjpk6rnv60q13wk56d6-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 337a4fe074be1042a35086f15481d763b8ddc0e7
+    revision: 3710e0e1218041bbad640352a0440114b1e10428
-    url: https://github.com/numtide/treefmt-nix/archive/337a4fe074be1042a35086f15481d763b8ddc0e7.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/3710e0e1218041bbad640352a0440114b1e10428.tar.gz
-    hash: sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=
+    hash: sha256-IjU1FxYqm+VDe5qIOxoW+pISBlGvVApRjiw/Y/ttJzY=
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre956909.93178f6a00c2/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre960315.608d0cadfed2/nixexprs.tar.xz
-    hash: sha256-xAHiI07j8nMZuA53r40AoWgYH9bKCgaVowNq5MpkE3g=
+    hash: sha256-ng4mTBcXO6Nc1cTlXxCPkI49nDJbwFNg/DBhx7YkymE=
[INFO ] Update successful.
```
</details>
