### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -81,9 +81,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -115,15 +115,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2024"
 [dependencies]
 rnix = "0.14.0"
 regex = "1.12.3"
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { version = "4.6.0", features = ["derive"] }
 serde_json = "1.0.149"
-tempfile = "3.26.0"
+tempfile = "3.27.0"
 serde = { version = "1.0.228", features = ["derive"] }
 anyhow = "1.0"
 colored = "3.1.1"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre960315.608d0cadfed2/nixexprs.tar.xz",
-      "hash": "sha256-ng4mTBcXO6Nc1cTlXxCPkI49nDJbwFNg/DBhx7YkymE="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre963717.a07d4ce6bee6/nixexprs.tar.xz",
+      "hash": "sha256-hfwXTZODckRv5CdezNotB9NgF/6y7j2K0DRoPwMXpFQ="
     },
     "treefmt-nix": {
       "type": "Git",
@@ -15,9 +15,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "3710e0e1218041bbad640352a0440114b1e10428",
-      "url": "https://github.com/numtide/treefmt-nix/archive/3710e0e1218041bbad640352a0440114b1e10428.tar.gz",
-      "hash": "sha256-IjU1FxYqm+VDe5qIOxoW+pISBlGvVApRjiw/Y/ttJzY="
+      "revision": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+      "url": "https://github.com/numtide/treefmt-nix/archive/71b125cd05fbfd78cab3e070b73544abe24c5016.tar.gz",
+      "hash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk="
     }
   },
   "version": 7


### PR DESCRIPTION
Running /nix/store/jw8568z4kih1bv4p6wkc9vqr7ds9va2x-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name     old req compatible latest new req
====     ======= ========== ====== =======
clap     4.5.60  4.6.0      4.6.0  4.6.0  
tempfile 3.26.0  3.27.0     3.27.0 3.27.0 
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.93.0 compatible versions
note: Re-run with `--verbose` to show more dependencies
  latest: 16 packages

```
### cargo update

```
    Updating crates.io index
     Locking 4 packages to latest Rust 1.93.0 compatible versions
    Updating anstyle v1.0.13 -> v1.0.14
    Updating clap_lex v1.0.0 -> v1.1.0
    Updating colorchoice v1.0.4 -> v1.0.5
    Updating once_cell v1.21.3 -> v1.21.4

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 950 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (100 crate dependencies)

```
</details>
Running /nix/store/nwa6xi035zdrl5icj0m9h9w3szsrfsdj-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.82.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.82.0
    cli | 2026/03/16 15:09:46 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/03/16 15:09:48 INFO Starting job processing
updater | 2026/03/16 15:09:48 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/03/16 15:09:49 INFO Base commit SHA: 6caecc59802d40498cf2577708b1f32636a7f548
updater | 2026/03/16 15:09:49 INFO Finished job processing
updater | 2026/03/16 15:09:49 INFO Starting job processing
updater | 2026/03/16 15:10:01 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/03/16 15:10:01 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/03/16 15:10:01 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/03/16 15:10:01 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon.rb:252:in 'Excon.get'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:193:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:164:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:34:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitMetadataFetcher#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:374:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:231:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:01 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/03/16 15:10:01 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/03/16 15:10:28 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/03/16 15:10:28 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/03/16 15:10:28 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/03/16 15:10:28 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.2.5/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:125:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:112:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/03/16 15:10:28 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/03/16 15:10:28 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/03/16 15:10:59 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/03/16 15:11:00 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/z8pj5ag10yfyjnv2m3q6z6imbzk5wkr0-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 3710e0e1218041bbad640352a0440114b1e10428
+    revision: 71b125cd05fbfd78cab3e070b73544abe24c5016
-    url: https://github.com/numtide/treefmt-nix/archive/3710e0e1218041bbad640352a0440114b1e10428.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/71b125cd05fbfd78cab3e070b73544abe24c5016.tar.gz
-    hash: sha256-IjU1FxYqm+VDe5qIOxoW+pISBlGvVApRjiw/Y/ttJzY=
+    hash: sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre960315.608d0cadfed2/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre963717.a07d4ce6bee6/nixexprs.tar.xz
-    hash: sha256-ng4mTBcXO6Nc1cTlXxCPkI49nDJbwFNg/DBhx7YkymE=
+    hash: sha256-hfwXTZODckRv5CdezNotB9NgF/6y7j2K0DRoPwMXpFQ=
[INFO ] Update successful.
```
</details>
