### PR TITLE
version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nixpkgs-vet"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixpkgs-vet"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
I think we have enough changes to warrant a release. I know there are pending PRs, but nothing's stopping us from releasing again after those are merged :).

Preliminary changelog (excluding automated updates):

* README.md: update for nixpkgs-vet by @philiptaron in https://github.com/NixOS/nixpkgs-vet/pull/106
* Number every problem reported by `nixpkgs-vet` by @philiptaron in https://github.com/NixOS/nixpkgs-vet/pull/109
* Fix new clippy lints by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/119
* .envrc: watch npins folder by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/118
* Clear some clippy::pedantic pings by @Ben-PH in https://github.com/NixOS/nixpkgs-vet/pull/120
* Lint cleanup by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/127
* Replace lazy_static with std::sync::LazyLock by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/123
* Ensure dependabot doesn't break over time by @infinisil in https://github.com/NixOS/nixpkgs-vet/pull/126
* readme: fix link to `builtins.currentSystem` by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/132
* Fix cargo upgrade to not break by using `--incompatible` by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/131
* workflows: fix xrefcheck detection on invalid symlinks in tests dir by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/140
* Use BTreeMap to get a sorted map instead of Vec + HashMap by @infinisil in https://github.com/NixOS/nixpkgs-vet/pull/143
* Update nixpkgs-check-by-name reference in CODEOWNERS by @infinisil in https://github.com/NixOS/nixpkgs-vet/pull/147
* File ratchet checks by @infinisil in https://github.com/NixOS/nixpkgs-vet/pull/144
* .github: run CI with `max-jobs` set to 1 in order to avoid OOM by @philiptaron in https://github.com/NixOS/nixpkgs-vet/pull/160
* feat: nixpkgs-vet --version by @dtomvan in https://github.com/NixOS/nixpkgs-vet/pull/158
* Update permissions by @infinisil in https://github.com/NixOS/nixpkgs-vet/pull/176
* Drop nix minimum to fix CI by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/177
* fix autoPrUpdate scripts/CI by @mdaniels5757 in https://github.com/NixOS/nixpkgs-vet/pull/183
* Update rust edition to 2024 by @willbush in https://github.com/NixOS/nixpkgs-vet/pull/179
* update npins by @mdaniels5757 in https://github.com/NixOS/nixpkgs-vet/pull/190
* CODEOWNERS: replace nixpkgs-vet with nixpkgs-ci team by @mdaniels5757 in https://github.com/NixOS/nixpkgs-vet/pull/192
* npins: switch nixpkgs from master branch back to nixpkgs-unstable channel by @mdaniels5757 in https://github.com/NixOS/nixpkgs-vet/pull/193
* Update rnix 0.12.0 to 0.14.0 with new path lints by @philiptaron in https://github.com/NixOS/nixpkgs-vet/pull/197
* Don't allow packages that start with dash or a digit by @Ben-PH in https://github.com/NixOS/nixpkgs-vet/pull/122
* Do not encourage merging with CI failure by @philiptaron in https://github.com/NixOS/nixpkgs-vet/pull/198
* Include wiki links in error output by @philiptaron in https://github.com/NixOS/nixpkgs-vet/pull/200

**Full Changelog**: https://github.com/NixOS/nixpkgs-vet/compare/0.1.4...0.2.0