### PR TITLE
use GitHub actions error annotations when possible

### DIFF
--- a/src/gh_write.rs
+++ b/src/gh_write.rs
@@ -1,0 +1,147 @@
+use std::{env, fmt};
+
+use relative_path::RelativePath;
+
+#[derive(Default, Debug)]
+pub enum Severity {
+    #[default]
+    Error,
+    // These aren't used but are included for completeness.
+    #[allow(dead_code)]
+    Warning,
+    #[allow(dead_code)]
+    Notice,
+}
+
+#[derive(Default, Debug)]
+pub struct Options<'a> {
+    pub file: Option<&'a RelativePath>,
+    pub start_line: Option<usize>, // 1-indexed
+    pub start_col: Option<usize>,  // 1-indexed
+    pub end_line: Option<usize>,   // 1-indexed
+    pub end_col: Option<usize>,    // 1-indexed
+    pub title: Option<&'a str>,
+    pub severity: Severity,
+}
+
+/// Write the formatted string "input" to "f", using the specified GitHub workflow commands
+/// See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+pub fn gh_write(
+    f: &mut impl fmt::Write,
+    input: String,
+    options: Options,
+) -> Result<(), fmt::Error> {
+    // Guess at final needed amount
+    let result: String = match env::var_os("GITHUB_ACTIONS") {
+        None => input,
+        Some(..) => {
+            let mut result = String::with_capacity(input.len() + 128);
+            match options.severity {
+                Severity::Notice => result.push_str("::notice"),
+                Severity::Warning => result.push_str("::warning"),
+                Severity::Error => result.push_str("::error"),
+            };
+
+            let mut params = vec![];
+            if let Some(title) = options.title {
+                params.push(format!("title={}", escape_property(title.to_string())))
+            }
+            if let Some(file) = options.file {
+                params.push(format!("file={}", escape_property(file.to_string())))
+            }
+            if let Some(start_line) = options.start_line {
+                params.push(format!("line={start_line}"))
+            }
+            if let Some(start_col) = options.start_col {
+                params.push(format!("col={start_col}"))
+            }
+            if let Some(end_line) = options.end_line {
+                params.push(format!("endLine={end_line}"))
+            }
+            if let Some(end_col) = options.end_col {
+                params.push(format!("endColumn={end_col}"))
+            }
+
+            if !params.is_empty() {
+                result.push_str(&format!(" {}", params.join(",")));
+            }
+
+            result.push_str("::");
+            result.push_str(&escape_data(input));
+            result
+        }
+    };
+
+    write!(f, "{}", result)
+}
+
+/// See https://github.com/actions/toolkit/blob/f31c2921c1228a97be08cdb38b919a83077354d9/packages/core/src/command.ts#L103-L117
+fn escape_data(input: String) -> String {
+    input
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+/// See https://github.com/actions/toolkit/blob/f31c2921c1228a97be08cdb38b919a83077354d9/packages/core/src/command.ts#L103-L117
+fn escape_property(input: String) -> String {
+    input
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+        .replace(':', "%3A")
+        .replace(',', "%2C")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gh_write::{Options, gh_write};
+    use pretty_assertions::assert_str_eq;
+    use relative_path::RelativePath;
+
+    fn test_gh_write(input: &str, options: Options, expected: impl ToString) {
+        let mut actual = String::new();
+        temp_env::with_var("GITHUB_ACTIONS", Some("1"), || {
+            gh_write(&mut actual, input.to_string(), options).unwrap()
+        });
+        assert_str_eq!(expected.to_string(), actual);
+    }
+
+    #[test]
+    fn simple_error_default() {
+        test_gh_write(
+            "hi",
+            Options {
+                ..Default::default()
+            },
+            "::error::hi",
+        );
+    }
+
+    #[test]
+    fn multiline_error_with_file_and_line() {
+        test_gh_write(
+            indoc::indoc!("
+            - Because pkgs/by-name/fo/foo exists, the attribute `pkgs.foo` must be defined like
+
+                foo = callPackage ./../by-name/fo/foo/package.nix { /* ... */ };
+
+            However, in this PR, it isn't defined that way. See the definition in pkgs/top-level/all-packages.nix:4
+
+                foo = self.bar;
+            (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-104)"),
+            Options {
+                file: Some(RelativePath::new("pkgs/top-level/all-packages.nix")),
+                start_line: Some(4),
+                ..Default::default()
+            },
+            "::error file=pkgs/top-level/all-packages.nix,line=4::".to_owned() +
+                "- Because pkgs/by-name/fo/foo exists, the attribute `pkgs.foo` must be defined like%0A%0A" +
+                "    foo = callPackage ./../by-name/fo/foo/package.nix { /* ... */ };%0A%0A" +
+                "However, in this PR, it isn't defined that way. " +
+                "See the definition in pkgs/top-level/all-packages.nix:4%0A%0A" +
+                "    foo = self.bar;%0A" +
+                "(https://github.com/NixOS/nixpkgs-vet/wiki/NPV-104)",
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 
 mod eval;
 mod files;
+mod gh_write;
 mod location;
 mod nix_file;
 mod problem;
@@ -166,7 +167,9 @@ mod tests {
             let expected_errors = fs::read_to_string(path.join("expected"))
                 .with_context(|| format!("No expected file for test {name}"))?;
 
-            test_nixpkgs(&name, &path, &expected_errors);
+            temp_env::with_var_unset("GITHUB_ACTIONS", || {
+                test_nixpkgs(&name, &path, &expected_errors)
+            });
         }
         Ok(())
     }
@@ -198,13 +201,15 @@ mod tests {
         fs::create_dir_all(base.join("fo/foO"))?;
         fs::write(base.join("fo/foO/package.nix"), "{ someDrv }: someDrv")?;
 
-        test_nixpkgs(
-            "case_sensitive",
-            path,
-            "- pkgs/by-name/fo: Duplicate case-sensitive package directories \"foO\" and \"foo\". (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-111)\n\
-            This PR introduces the problems listed above. Please fix them before merging, \
-            otherwise the base branch would break.\n",
-        );
+        temp_env::with_var_unset("GITHUB_ACTIONS", || {
+            test_nixpkgs(
+                "case_sensitive",
+                path,
+                "- pkgs/by-name/fo: Duplicate case-sensitive package directories \"foO\" and \"foo\". (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-111)\n\
+                This PR introduces the problems listed above. Please fix them before merging, \
+                otherwise the base branch would break.\n",
+            )
+        });
         Ok(())
     }
 

--- a/src/problem/npv_100.rs
+++ b/src/problem/npv_100.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -14,9 +15,15 @@ impl fmt::Display for ByNameUndefinedAttribute {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { attribute_name } = self;
         let relative_package_file = structure::relative_file_for_package(attribute_name);
-        write!(
+        gh_write(
             f,
-            "- pkgs.{attribute_name}: This attribute is not defined but it should be defined automatically as {relative_package_file}",
+            format!(
+                "- pkgs.{attribute_name}: This attribute is not defined but it should be defined automatically as {relative_package_file}"
+            ),
+            Options {
+                file: Some(&relative_package_file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_101.rs
+++ b/src/problem/npv_101.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -14,9 +15,14 @@ impl fmt::Display for ByNameNonDerivation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { attribute_name } = self;
         let relative_package_file = structure::relative_file_for_package(attribute_name);
-        write!(
+        gh_write(
             f,
-            "- pkgs.{attribute_name}: This attribute defined by {relative_package_file} is not a derivation",
+            format!(
+                "- pkgs.{attribute_name}: This attribute defined by {relative_package_file} is not a derivation"
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_102.rs
+++ b/src/problem/npv_102.rs
@@ -2,6 +2,8 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
+
 #[derive(Clone, new)]
 pub struct ByNameInternalCallPackageUsed {
     #[new(into)]
@@ -11,9 +13,14 @@ pub struct ByNameInternalCallPackageUsed {
 impl fmt::Display for ByNameInternalCallPackageUsed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { attribute_name } = self;
-        write!(
+        gh_write(
             f,
-            "- pkgs.{attribute_name}: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use.",
+            format!(
+                "- pkgs.{attribute_name}: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use."
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_103.rs
+++ b/src/problem/npv_103.rs
@@ -2,6 +2,8 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
+
 #[derive(Clone, new)]
 pub struct ByNameCannotDetermineAttributeLocation {
     #[new(into)]
@@ -11,9 +13,14 @@ pub struct ByNameCannotDetermineAttributeLocation {
 impl fmt::Display for ByNameCannotDetermineAttributeLocation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { attribute_name } = self;
-        write!(
+        gh_write(
             f,
-            "- pkgs.{attribute_name}: Cannot determine the location of this attribute using `builtins.unsafeGetAttrPos`.",
+            format!(
+                "- pkgs.{attribute_name}: Cannot determine the location of this attribute using `builtins.unsafeGetAttrPos`.",
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_104.rs
+++ b/src/problem/npv_104.rs
@@ -1,12 +1,12 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
-
-use crate::location::Location;
-use crate::structure;
+use indoc::formatdoc;
 
 use super::{create_path_expr, indent_definition};
+use crate::gh_write::{Options, gh_write};
+use crate::location::Location;
+use crate::structure;
 
 #[derive(Clone, new)]
 pub struct ByNameOverrideOfNonSyntacticCallPackage {
@@ -30,17 +30,25 @@ impl fmt::Display for ByNameOverrideOfNonSyntacticCallPackage {
         let expected_path_expr = create_path_expr(file, expected_package_path);
         let indented_definition = indent_definition(*column, definition);
 
-        writedoc!(
+        gh_write(
             f,
-            "
-            - Because {relative_package_dir} exists, the attribute `pkgs.{package_name}` must be defined like
+            formatdoc!(
+                "
+                - Because {relative_package_dir} exists, the attribute `pkgs.{package_name}` must be defined like
 
-                {package_name} = callPackage {expected_path_expr} {{ /* ... */ }};
+                    {package_name} = callPackage {expected_path_expr} {{ /* ... */ }};
 
-              However, in this PR, it isn't defined that way. See the definition in {file}:{line}
+                  However, in this PR, it isn't defined that way. See the definition in {file}:{line}
 
-            {indented_definition}
-            ",
+                {indented_definition}
+                ",
+            ),
+            Options {
+                file: Some(file),
+                start_line: Some(*line),
+                start_col: Some(*column),
+                ..Default::default()
+            }
         )
     }
 }

--- a/src/problem/npv_105.rs
+++ b/src/problem/npv_105.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 
+use crate::gh_write::{Options, gh_write};
 use crate::location::Location;
 use crate::structure;
 
@@ -30,9 +31,9 @@ impl fmt::Display for ByNameOverrideOfNonTopLevelPackage {
         let expected_path_expr = create_path_expr(file, expected_package_path);
         let indented_definition = indent_definition(*column, definition);
 
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Because {relative_package_dir} exists, the attribute `pkgs.{package_name}` must be defined like
 
                 {package_name} = callPackage {expected_path_expr} {{ /* ... */ }};
@@ -40,7 +41,13 @@ impl fmt::Display for ByNameOverrideOfNonTopLevelPackage {
               However, in this PR, a different `callPackage` is used. See the definition in {file}:{line}:
 
             {indented_definition}
-            ",
+            "),
+            Options {
+                file: Some(file),
+                start_line: Some(*line),
+                start_col: Some(*column),
+                ..Default::default()
+            }
         )
     }
 }

--- a/src/problem/npv_106.rs
+++ b/src/problem/npv_106.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
+use crate::gh_write::{Options, gh_write};
 use crate::location::Location;
 use crate::structure;
 
@@ -25,14 +26,14 @@ impl fmt::Display for ByNameOverrideContainsWrongCallPackagePath {
             location,
             actual_path,
         } = self;
-        let Location { file, line, .. } = location;
+        let Location { file, line, column } = location;
         let expected_package_path = structure::relative_file_for_package(package_name);
         let expected_path_expr = create_path_expr(file, expected_package_path);
         let relative_package_dir = structure::relative_dir_for_package(package_name);
         let actual_path_expr = create_path_expr(file, actual_path);
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Because {relative_package_dir} exists, the attribute `pkgs.{package_name}` must be defined like
 
                 {package_name} = callPackage {expected_path_expr} {{ /* ... */ }};
@@ -40,7 +41,13 @@ impl fmt::Display for ByNameOverrideContainsWrongCallPackagePath {
               However, in this PR, the first `callPackage` argument is the wrong path. See the definition in {file}:{line}:
 
                 {package_name} = callPackage {actual_path_expr} {{ /* ... */ }};
-            ",
+            "),
+            Options {
+                file: Some(file),
+                start_line: Some(*line),
+                start_col: Some(*column),
+                ..Default::default()
+            }
         )
     }
 }

--- a/src/problem/npv_107.rs
+++ b/src/problem/npv_107.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 
+use crate::gh_write::{Options, gh_write};
 use crate::location::Location;
 use crate::structure;
 
@@ -30,9 +31,9 @@ impl fmt::Display for ByNameOverrideContainsEmptyArgument {
         let relative_package_dir = structure::relative_dir_for_package(package_name);
         let indented_definition = indent_definition(*column, definition);
 
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Because {relative_package_dir} exists, the attribute `pkgs.{package_name}` must be defined like
 
                 {package_name} = callPackage {expected_path_expr} {{ /* ... */ }};
@@ -42,7 +43,13 @@ impl fmt::Display for ByNameOverrideContainsEmptyArgument {
             {indented_definition}
 
               Such a definition is provided automatically and therefore not necessary. Please remove it.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                start_line: Some(*line),
+                start_col: Some(*column),
+                ..Default::default()
+            }
         )
     }
 }

--- a/src/problem/npv_108.rs
+++ b/src/problem/npv_108.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 
+use crate::gh_write::{Options, gh_write};
 use crate::location::Location;
 use crate::structure;
 
@@ -30,9 +31,9 @@ impl fmt::Display for ByNameOverrideContainsEmptyPath {
         let expected_path_expr = create_path_expr(file, expected_package_path);
         let indented_definition = indent_definition(*column, definition);
 
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Because {relative_package_dir} exists, the attribute `pkgs.{package_name}` must be defined like
 
                 {package_name} = callPackage {expected_path_expr} {{ /* ... */ }};
@@ -40,7 +41,13 @@ impl fmt::Display for ByNameOverrideContainsEmptyPath {
               However, in this PR, the first `callPackage` argument is not a path. See the definition in {file}:{line}:
 
             {indented_definition}
-            ",
+            "),
+            Options {
+                file: Some(file),
+                start_line: Some(*line),
+                start_col: Some(*column),
+                ..Default::default()
+            }
         )
     }
 }

--- a/src/problem/npv_109.rs
+++ b/src/problem/npv_109.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 
 use crate::structure;
@@ -13,9 +14,12 @@ pub struct ByNameShardIsNotDirectory {
 impl fmt::Display for ByNameShardIsNotDirectory {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let relative_shard_path = structure::relative_dir_for_shard(&self.shard_name);
-        write!(
+        gh_write(
             f,
-            "- {relative_shard_path}: This is a file, but it should be a directory.",
+            format!("- {relative_shard_path}: This is a file, but it should be a directory."),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_110.rs
+++ b/src/problem/npv_110.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 
 use crate::structure;
@@ -14,9 +15,14 @@ impl fmt::Display for ByNameShardIsInvalid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let shard_name = &self.shard_name;
         let relative_shard_path = structure::relative_dir_for_shard(shard_name);
-        write!(
+        gh_write(
             f,
-            "- {relative_shard_path}: Invalid directory name \"{shard_name}\", must be at most 2 ASCII characters, starting with a-z or \"_\", consisting of a-z, 0-9, \"-\" or \"_\".",
+            format!(
+                "- {relative_shard_path}: Invalid directory name \"{shard_name}\", must be at most 2 ASCII characters, starting with a-z or \"_\", consisting of a-z, 0-9, \"-\" or \"_\"."
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_111.rs
+++ b/src/problem/npv_111.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -18,9 +19,14 @@ impl fmt::Display for ByNameShardIsCaseSensitiveDuplicate {
         let relative_shard_path = structure::relative_dir_for_shard(&self.shard_name);
         let first = self.first.to_string_lossy();
         let second = self.second.to_string_lossy();
-        write!(
+        gh_write(
             f,
-            "- {relative_shard_path}: Duplicate case-sensitive package directories \"{first}\" and \"{second}\"."
+            format!(
+                "- {relative_shard_path}: Duplicate case-sensitive package directories \"{first}\" and \"{second}\"."
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_120.rs
+++ b/src/problem/npv_120.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 
 #[derive(Clone, new)]
@@ -11,9 +12,13 @@ pub struct NixEvalError {
 impl fmt::Display for NixEvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&self.stderr)?;
-        write!(
+        gh_write(
             f,
             "- Nix evaluation failed for some package in `pkgs/by-name`, see error above"
+                .to_string(),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_121.rs
+++ b/src/problem/npv_121.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -22,9 +23,16 @@ impl fmt::Display for NixFileContainsPathInterpolation {
             line,
             text,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: File {subpath} at line {line} contains the path expression \"{text}\", which is not yet supported and may point outside the directory of that package.",
+            format!(
+                "- {relative_package_dir}: File {subpath} at line {line} contains the path expression \"{text}\", which is not yet supported and may point outside the directory of that package."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                start_line: Some(*line),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_122.rs
+++ b/src/problem/npv_122.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -22,9 +23,16 @@ impl fmt::Display for NixFileContainsSearchPath {
             line,
             text,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: File {subpath} at line {line} contains the nix search path expression \"{text}\" which may point outside the directory of that package.",
+            format!(
+                "- {relative_package_dir}: File {subpath} at line {line} contains the nix search path expression \"{text}\" which may point outside the directory of that package."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                start_line: Some(*line),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_123.rs
+++ b/src/problem/npv_123.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure::PACKAGE_NIX_FILENAME;
 
 #[derive(Clone, new)]
@@ -25,9 +26,9 @@ impl fmt::Display for NixFileContainsPathOutsideDirectory {
             line,
             text,
         } = self;
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - {relative_package_dir}: File {subpath} at line {line} contains the path expression \"{text}\" which may point outside the directory of that package.
               This is undesirable because it creates dependencies between internal paths, making it harder to reorganise Nixpkgs in the future.
               Alternatives include:
@@ -35,7 +36,12 @@ impl fmt::Display for NixFileContainsPathOutsideDirectory {
               - If the path being referenced could be considered a stable interface with multiple uses, consider exposing it via a `pkgs` attribute, then taking it as a attribute argument in {PACKAGE_NIX_FILENAME}.
               - If the path being referenced is internal and has multiple uses, consider passing the file as an explicit `callPackage` argument in `pkgs/top-level/all-packages.nix`.
               - If the path being referenced is internal and will need to be modified independently of the original, consider copying it into the {relative_package_dir} directory.
-            "
+            "),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                start_line: Some(*line),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_124.rs
+++ b/src/problem/npv_124.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::{fmt, io};
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -26,9 +27,16 @@ impl fmt::Display for NixFileContainsUnresolvablePath {
             text,
             io_error,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: File {subpath} at line {line} contains the path expression \"{text}\" which cannot be resolved: {io_error}.",
+            format!(
+                "- {relative_package_dir}: File {subpath} at line {line} contains the path expression \"{text}\" which cannot be resolved: {io_error}."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                start_line: Some(*line),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_125.rs
+++ b/src/problem/npv_125.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -17,9 +18,15 @@ impl fmt::Display for PackageContainsSymlinkPointingOutside {
             relative_package_dir,
             subpath,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: Path {subpath} is a symlink pointing to a path outside the directory of that package.",
+            format!(
+                "- {relative_package_dir}: Path {subpath} is a symlink pointing to a path outside the directory of that package."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_126.rs
+++ b/src/problem/npv_126.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::{fmt, io};
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -21,9 +22,15 @@ impl fmt::Display for PackageContainsUnresolvableSymlink {
             subpath,
             io_error,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: Path {subpath} is a symlink which cannot be resolved: {io_error}.",
+            format!(
+                "- {relative_package_dir}: Path {subpath} is a symlink which cannot be resolved: {io_error}."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_127.rs
+++ b/src/problem/npv_127.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -22,9 +23,16 @@ impl fmt::Display for NixFileContainsAbsolutePath {
             line,
             text,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: File {subpath} at line {line} contains the absolute path expression \"{text}\", which is not allowed in nixpkgs.",
+            format!(
+                "- {relative_package_dir}: File {subpath} at line {line} contains the absolute path expression \"{text}\", which is not allowed in nixpkgs."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                start_line: Some(*line),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_128.rs
+++ b/src/problem/npv_128.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -22,9 +23,16 @@ impl fmt::Display for NixFileContainsHomeRelativePath {
             line,
             text,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: File {subpath} at line {line} contains the home-relative path expression \"{text}\", which is not allowed in nixpkgs.",
+            format!(
+                "- {relative_package_dir}: File {subpath} at line {line} contains the home-relative path expression \"{text}\", which is not allowed in nixpkgs."
+            ),
+            Options {
+                file: Some(&relative_package_dir.join(subpath)),
+                start_line: Some(*line),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_140.rs
+++ b/src/problem/npv_140.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -14,9 +15,12 @@ impl fmt::Display for PackageDirectoryIsNotDirectory {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name } = self;
         let relative_package_dir = structure::relative_dir_for_package(package_name);
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: This path is a file, but it should be a directory.",
+            format!("- {relative_package_dir}: This path is a file, but it should be a directory."),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_141.rs
+++ b/src/problem/npv_141.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -17,9 +18,14 @@ impl fmt::Display for InvalidPackageDirectoryName {
             package_name,
             relative_package_dir,
         } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: Invalid package directory name \"{package_name}\", must start with a letter (a-z, A-Z) or \"_\", followed by ASCII characters a-z, A-Z, 0-9, \"-\" or \"_\".",
+            format!(
+                "- {relative_package_dir}: Invalid package directory name \"{package_name}\", must start with a letter (a-z, A-Z) or \"_\", followed by ASCII characters a-z, A-Z, 0-9, \"-\" or \"_\"."
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_142.rs
+++ b/src/problem/npv_142.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -20,9 +21,14 @@ impl fmt::Display for PackageInWrongShard {
             relative_package_dir,
         } = self;
         let correct_relative_package_dir = structure::relative_dir_for_package(package_name);
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: Incorrect directory location, should be {correct_relative_package_dir} instead.",
+            format!(
+                "- {relative_package_dir}: Incorrect directory location, should be {correct_relative_package_dir} instead."
+            ),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_143.rs
+++ b/src/problem/npv_143.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure::{self, PACKAGE_NIX_FILENAME};
 
 #[derive(Clone, new)]
@@ -14,9 +15,12 @@ impl fmt::Display for PackageNixMissing {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name } = self;
         let relative_package_dir = structure::relative_dir_for_package(package_name);
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: Missing required \"{PACKAGE_NIX_FILENAME}\" file.",
+            format!("- {relative_package_dir}: Missing required \"{PACKAGE_NIX_FILENAME}\" file."),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_144.rs
+++ b/src/problem/npv_144.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use derive_new::new;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure::{self, PACKAGE_NIX_FILENAME};
 
 #[derive(Clone, new)]
@@ -14,9 +15,12 @@ impl fmt::Display for PackageNixIsNotFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name } = self;
         let relative_package_dir = structure::relative_dir_for_package(package_name);
-        write!(
+        gh_write(
             f,
-            "- {relative_package_dir}: \"{PACKAGE_NIX_FILENAME}\" must be a file.",
+            format!("- {relative_package_dir}: \"{PACKAGE_NIX_FILENAME}\" must be a file."),
+            Options {
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_145.rs
+++ b/src/problem/npv_145.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -12,9 +13,15 @@ pub struct NixFileIsExecutableWithoutShebang {
 impl fmt::Display for NixFileIsExecutableWithoutShebang {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { relative_path } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_path}: Nix files must not be executable unless they have a shebang (`#!`) line.",
+            format!(
+                "- {relative_path}: Nix files must not be executable unless they have a shebang (`#!`) line."
+            ),
+            Options {
+                file: Some(relative_path),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_146.rs
+++ b/src/problem/npv_146.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
 use relative_path::RelativePathBuf;
 
@@ -12,9 +13,13 @@ pub struct NixFileHasShebangButNotExecutable {
 impl fmt::Display for NixFileHasShebangButNotExecutable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { relative_path } = self;
-        write!(
+        gh_write(
             f,
-            "- {relative_path}: Nix files with a shebang (`#!`) line must be executable.",
+            format!("- {relative_path}: Nix files with a shebang (`#!`) line must be executable."),
+            Options {
+                file: Some(relative_path),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_160.rs
+++ b/src/problem/npv_160.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
 use crate::structure;
@@ -27,12 +28,16 @@ impl fmt::Display for TopLevelPackageMovedOutOfByName {
         let call_package_arg = call_package_path
             .as_ref()
             .map_or_else(|| "...".into(), |path| format!("./{}", path));
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` was previously defined in {relative_package_file}, but is now manually defined as `callPackage {call_package_arg} {{ /* ... */ }}` in {file}.
               Please move the package back and remove the manual `callPackage`.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_161.rs
+++ b/src/problem/npv_161.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
 use crate::structure;
@@ -27,12 +28,16 @@ impl fmt::Display for TopLevelPackageMovedOutOfByNameWithCustomArguments {
         let call_package_arg = call_package_path
             .as_ref()
             .map_or_else(|| "...".into(), |path| format!("./{}", path));
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` was previously defined in {relative_package_file}, but is now manually defined as `callPackage {call_package_arg} {{ ... }}` in {file}.
               While the manual `callPackage` is still needed, it's not necessary to move the package files.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_162.rs
+++ b/src/problem/npv_162.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -27,14 +28,18 @@ impl fmt::Display for NewTopLevelPackageShouldBeByName {
         let call_package_arg = call_package_path
             .as_ref()
             .map_or_else(|| "...".into(), |path| format!("./{}", path));
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` is a new top-level package using `pkgs.callPackage {call_package_arg} {{ /* ... */ }}`.
               Please define it in {relative_package_file} instead.
               See `pkgs/by-name/README.md` for more details.
               Since the second `callPackage` argument is `{{ }}`, no manual `callPackage` in {file} is needed anymore.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_163.rs
+++ b/src/problem/npv_163.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
+use crate::gh_write::{Options, gh_write};
 use crate::structure;
 
 #[derive(Clone, new)]
@@ -27,14 +28,18 @@ impl fmt::Display for NewTopLevelPackageShouldBeByNameWithCustomArgument {
         let call_package_arg = call_package_path
             .as_ref()
             .map_or_else(|| "...".into(), |path| format!("./{}", path));
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` is a new top-level package using `pkgs.callPackage {call_package_arg} {{ /* ... */ }}`.
               Please define it in {relative_package_file} instead.
               See `pkgs/by-name/README.md` for more details.
               Since the second `callPackage` argument is not `{{ }}`, the manual `callPackage` in {file} is still needed.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_164.rs
+++ b/src/problem/npv_164.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
 #[derive(Clone, new)]
@@ -15,12 +16,16 @@ pub struct NewTopLevelPackageMustEnableStrictDeps {
 impl fmt::Display for NewTopLevelPackageMustEnableStrictDeps {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name, file } = self;
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` is a new package with `strictDeps` unset or set to `false`.
               Please enable `strictDeps = true;` in {file}.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_165.rs
+++ b/src/problem/npv_165.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
 #[derive(Clone, new)]
@@ -15,12 +16,16 @@ pub struct TopLevelPackageDisabledStrictDeps {
 impl fmt::Display for TopLevelPackageDisabledStrictDeps {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name, file } = self;
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` previously evaluated with `strictDeps = true`, but now evaluates with `strictDeps = false`.
               Please re-enable `strictDeps = true;` in {file}.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_166.rs
+++ b/src/problem/npv_166.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
 #[derive(Clone, new)]
@@ -15,12 +16,16 @@ pub struct NewTopLevelPackageMustEnableStructuredAttrs {
 impl fmt::Display for NewTopLevelPackageMustEnableStructuredAttrs {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name, file } = self;
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` is a new package with `__structuredAttrs` unset or set to `false`.
               Please enable `__structuredAttrs = true;` in {file}.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_167.rs
+++ b/src/problem/npv_167.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
+use crate::gh_write::{Options, gh_write};
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 use relative_path::RelativePathBuf;
 
 #[derive(Clone, new)]
@@ -15,12 +16,16 @@ pub struct TopLevelPackageDisabledStructuredAttrs {
 impl fmt::Display for TopLevelPackageDisabledStructuredAttrs {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { package_name, file } = self;
-        writedoc!(
+        gh_write(
             f,
-            "
+            formatdoc!("
             - Attribute `pkgs.{package_name}` previously evaluated with `__structuredAttrs = true`, but now evaluates with `__structuredAttrs = false`.
               Please re-enable `__structuredAttrs = true;` in {file}.
-            ",
+            "),
+            Options {
+                file: Some(file),
+                ..Default::default()
+            },
         )
     }
 }

--- a/src/problem/npv_170.rs
+++ b/src/problem/npv_170.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use derive_new::new;
-use indoc::writedoc;
+use indoc::formatdoc;
 
+use crate::gh_write::{Options, gh_write};
 use crate::location::Location;
 
 #[derive(Clone, new)]
@@ -28,19 +29,27 @@ impl fmt::Display for NixFileContainsUselessEscape {
                 fixed_escape,
             ),
         };
-        writedoc!(
+        gh_write(
             f,
-            "
-            - {}: line {}, column {} contains the escape \"{}\".
-              This escape has no effect; it is equivalent to \"{}\".
-              {}
-            ",
-            location.file,
-            location.line,
-            location.column,
-            current_escape,
-            without_escape,
-            fixed_escape_text,
+            formatdoc!(
+                "
+                - {}: line {}, column {} contains the escape \"{}\".
+                  This escape has no effect; it is equivalent to \"{}\".
+                  {}
+                ",
+                location.file,
+                location.line,
+                location.column,
+                current_escape,
+                without_escape,
+                fixed_escape_text,
+            ),
+            Options {
+                file: Some(&location.file),
+                start_line: Some(location.line),
+                start_col: Some(location.column),
+                ..Default::default()
+            },
         )
     }
 }


### PR DESCRIPTION
Closes: #93

I made this, but now I'm not sure we should actually use it. This is because there is no way (that I'm aware of) to hide/delete old annotations (e.g. from prior runs), so duplicates (or no-longer-applying) annotations will still be present. See https://github.com/mdaniels5757/unconnected-nixpkgs/pull/99/changes for an example of this.

Possibly this should stay a draft until https://github.com/orgs/community/discussions/84043 or https://github.com/orgs/community/discussions/16661)? But I suspect we're going to need to wait a while for that...
