### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -282,12 +282,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -330,9 +330,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre975217.5e11f7acce6c/nixexprs.tar.xz",
-      "hash": "sha256-avkT2TR2Wh/TQTysYGFOkGiF5+2R2nS7TZOfQ4omieQ="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz",
+      "hash": "sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM="
     },
     "treefmt-nix": {
       "type": "Git",
@@ -15,9 +15,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "75925962939880974e3ab417879daffcba36c4a3",
-      "url": "https://github.com/numtide/treefmt-nix/archive/75925962939880974e3ab417879daffcba36c4a3.tar.gz",
-      "hash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U="
+      "revision": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+      "url": "https://github.com/numtide/treefmt-nix/archive/790751ff7fd3801feeaf96d7dc416a8d581265ba.tar.gz",
+      "hash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0="
     }
   },
   "version": 7


### PR DESCRIPTION
Running /nix/store/kfmkvfgsqzrcn2ccp2bj0vc9igbb2f7k-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 18 packages

```
### cargo update

```
    Updating crates.io index
     Locking 4 packages to latest Rust 1.94.0 compatible versions
    Updating fastrand v2.4.0 -> v2.4.1
    Updating hashbrown v0.16.1 -> v0.17.0
    Updating indexmap v2.13.1 -> v2.14.0
    Updating libc v0.2.184 -> v0.2.185

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1043 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (100 crate dependencies)

```
</details>
Running /nix/store/6918x3nfr8cpwdpfx3rhmi98ppmilr2y-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.85.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.85.0
    cli | 2026/04/13 15:12:10 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/04/13 15:12:14 INFO Starting job processing
updater | 2026/04/13 15:12:14 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/04/13 15:12:27 WARN Could not validate the existence of the 'dependabot' branch: No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/04/13 15:12:27 INFO Started process PID: 1142 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1142 completed with status: pid 1142 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1150 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1150 completed with status: pid 1150 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1157 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1157 completed with status: pid 1157 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1164 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.02 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1171 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1171 completed with status: pid 1171 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1178 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1178 completed with status: pid 1178 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1185 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1185 completed with status: pid 1185 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1192 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1192 completed with status: pid 1192 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1199 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1199 completed with status: pid 1199 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1206 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1206 completed with status: pid 1206 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1213 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1213 completed with status: pid 1213 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1228 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1228 completed with status: pid 1228 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1236 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1236 completed with status: pid 1236 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1243 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1243 completed with status: pid 1243 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1250 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1250 completed with status: pid 1250 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1257 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1257 completed with status: pid 1257 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1264 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1264 completed with status: pid 1264 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1271 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1271 completed with status: pid 1271 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1278 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1278 completed with status: pid 1278 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1285 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1285 completed with status: pid 1285 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1292 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1292 completed with status: pid 1292 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1299 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1299 completed with status: pid 1299 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1306 with command: {} git rev-parse HEAD {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1306 completed with status: pid 1306 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1321 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1321 completed with status: pid 1321 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1329 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1329 completed with status: pid 1329 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1336 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1336 completed with status: pid 1336 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1343 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1343 completed with status: pid 1343 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1350 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1350 completed with status: pid 1350 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1357 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1357 completed with status: pid 1357 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1364 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1364 completed with status: pid 1364 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1371 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1371 completed with status: pid 1371 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1378 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1378 completed with status: pid 1378 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1385 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1385 completed with status: pid 1385 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.01 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1392 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1392 completed with status: pid 1392 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Started process PID: 1399 with command: {} git rev-parse HEAD {}
updater | 2026/04/13 15:12:27 INFO Process PID: 1399 completed with status: pid 1399 exit 0
updater | 2026/04/13 15:12:27 INFO Total execution time: 0.0 seconds
updater | 2026/04/13 15:12:27 INFO Base commit SHA: e3956d13d49d7dc36e5bc71591941747131949bb
updater | 2026/04/13 15:12:27 INFO Finished job processing
updater | 2026/04/13 15:12:27 INFO Starting job processing
updater | 2026/04/13 15:12:39 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/04/13 15:12:39 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/04/13 15:12:39 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/04/13 15:12:39 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon.rb:252:in 'Excon.get'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:209:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:180:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:50:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_medium0'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:407:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:244:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:12:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/04/13 15:12:39 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/04/13 15:13:10 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/04/13 15:13:10 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/04/13 15:13:10 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/04/13 15:13:10 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:124:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:111:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/04/13 15:13:10 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/04/13 15:13:10 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/04/13 15:13:41 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/04/13 15:13:41 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/zg8jcszvp3xf79nr14jqf4hdwf9g3vg2-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 75925962939880974e3ab417879daffcba36c4a3
+    revision: 790751ff7fd3801feeaf96d7dc416a8d581265ba
-    url: https://github.com/numtide/treefmt-nix/archive/75925962939880974e3ab417879daffcba36c4a3.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/790751ff7fd3801feeaf96d7dc416a8d581265ba.tar.gz
-    hash: sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=
+    hash: sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre975217.5e11f7acce6c/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz
-    hash: sha256-avkT2TR2Wh/TQTysYGFOkGiF5+2R2nS7TZOfQ4omieQ=
+    hash: sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM=
[INFO ] Update successful.
```
</details>
