### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"
@@ -81,9 +81,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -727,11 +727,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -800,6 +800,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 rnix = "0.14.0"
 regex = "1.12.3"
-clap = { version = "4.6.0", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.27.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz",
-      "hash": "sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre981196.b86751bc4085/nixexprs.tar.xz",
+      "hash": "sha256-mBqzkn7oJti2hqeO8iTbDxKw+1ifxpP53feQ0CEXies="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/kfmkvfgsqzrcn2ccp2bj0vc9igbb2f7k-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.6.0   4.6.1      4.6.1  4.6.1  
   Upgrading recursive dependencies
     Locking 0 packages to latest Rust 1.94.0 compatible versions
note: Re-run with `--verbose` to show more dependencies
  latest: 17 packages

```
### cargo update

```
    Updating crates.io index
     Locking 3 packages to latest Rust 1.94.0 compatible versions
    Updating bitflags v2.11.0 -> v2.11.1
    Updating wasip2 v1.0.2+wasi-0.2.9 -> v1.0.3+wasi-0.2.9
      Adding wit-bindgen v0.57.1

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1049 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (101 crate dependencies)

```
</details>
Running /nix/store/ah83g9pk51fh67kqrrx3bi69kv7xpslp-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.85.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.85.0
    cli | 2026/04/20 15:12:17 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/04/20 15:12:20 INFO Starting job processing
updater | 2026/04/20 15:12:20 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/04/20 15:12:33 WARN Could not validate the existence of the 'dependabot' branch: No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/04/20 15:12:33 INFO Started process PID: 1142 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1142 completed with status: pid 1142 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1150 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1150 completed with status: pid 1150 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1157 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1157 completed with status: pid 1157 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1164 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.02 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1172 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1172 completed with status: pid 1172 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1179 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1179 completed with status: pid 1179 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1186 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1186 completed with status: pid 1186 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1193 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1193 completed with status: pid 1193 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1200 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1200 completed with status: pid 1200 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1207 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1207 completed with status: pid 1207 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1214 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1214 completed with status: pid 1214 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1229 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1229 completed with status: pid 1229 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1237 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1237 completed with status: pid 1237 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1244 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1244 completed with status: pid 1244 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1251 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1251 completed with status: pid 1251 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1258 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1258 completed with status: pid 1258 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1265 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1265 completed with status: pid 1265 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1272 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1272 completed with status: pid 1272 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1279 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1279 completed with status: pid 1279 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1286 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1286 completed with status: pid 1286 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1294 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1294 completed with status: pid 1294 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1301 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1301 completed with status: pid 1301 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1308 with command: {} git rev-parse HEAD {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1308 completed with status: pid 1308 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1323 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1323 completed with status: pid 1323 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1331 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1331 completed with status: pid 1331 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1338 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1338 completed with status: pid 1338 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1345 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1345 completed with status: pid 1345 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1352 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1352 completed with status: pid 1352 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1359 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1359 completed with status: pid 1359 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1366 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1366 completed with status: pid 1366 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1373 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1373 completed with status: pid 1373 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1380 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1380 completed with status: pid 1380 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1387 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1387 completed with status: pid 1387 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.01 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1394 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1394 completed with status: pid 1394 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Started process PID: 1401 with command: {} git rev-parse HEAD {}
updater | 2026/04/20 15:12:33 INFO Process PID: 1401 completed with status: pid 1401 exit 0
updater | 2026/04/20 15:12:33 INFO Total execution time: 0.0 seconds
updater | 2026/04/20 15:12:33 INFO Base commit SHA: de9704a7a5f8bb8377c3d59121d1c10b97496be7
updater | 2026/04/20 15:12:33 INFO Finished job processing
updater | 2026/04/20 15:12:33 INFO Starting job processing
updater | 2026/04/20 15:12:45 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/04/20 15:12:45 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/04/20 15:12:45 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/04/20 15:12:45 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon.rb:252:in 'Excon.get'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:209:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:180:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:50:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_medium0'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:407:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:244:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:12:45 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/04/20 15:12:45 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/04/20 15:13:11 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/04/20 15:13:11 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/04/20 15:13:11 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/04/20 15:13:11 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:124:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:111:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/04/20 15:13:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/04/20 15:13:11 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/04/20 15:13:40 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/04/20 15:13:40 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/qkc5qcmk4rl371lfd86kx3lcfnnhflx7-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre981196.b86751bc4085/nixexprs.tar.xz
-    hash: sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM=
+    hash: sha256-mBqzkn7oJti2hqeO8iTbDxKw+1ifxpP53feQ0CEXies=
[INFO ] Update successful.
```
</details>
