### PR TITLE
ci: pin all GitHub actions, setup pinact/actionlint/zizmor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           extra_nix_config: |
             max-jobs = 1
@@ -43,11 +43,11 @@ jobs:
   xrefcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # While this has a Nix build available, it needs to evaluate and build so much
       # that I don't think it's worth adding it to the nix-build.
-      - uses: serokell/xrefcheck-action@v1
+      - uses: serokell/xrefcheck-action@81d3967156933307f52fc52f8dc7fa5e947509c2 # v1.0.3
         with: # Invalid symlinks for testing purposes.
           xrefcheck-args: >
             --ignore tests/symlink-invalid/main/pkgs/by-name/fo/foo/foo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,10 @@ jobs:
           extra_nix_config: |
             max-jobs = 1
 
+      # This can't be done in the treefmt check because it needs network access
+      - name: check action pins
+        run: nix run -f default.nix pkgs.pinact -- run -check -verify -diff
+
       - name: build
         run: nix-build -A ci
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,18 @@ concurrency:
   # Better wait until it's done
   cancel-in-progress: ${{ github.event_name != 'pull' }}
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
@@ -48,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # While this has a Nix build available, it needs to evaluate and build so much
       # that I don't think it's worth adding it to the nix-build.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,10 +8,12 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: repo
+          persist-credentials: ${{ github.event_name != 'pull_request' }}
 
       - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
@@ -34,7 +36,7 @@ jobs:
             echo '```diff'
             git -C repo diff
             echo '```'
-          } > $GITHUB_STEP_SUMMARY
+          } > "$GITHUB_STEP_SUMMARY"
 
       - name: Create Pull Request
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,11 +9,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: repo
 
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           extra_nix_config: |
             max-jobs = 1
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ github.event_name != 'pull_request' }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           # To trigger CI for automated PRs, we use a separate machine account
           # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,8 @@ let
     programs.nixfmt.enable = true;
     programs.rustfmt.enable = true;
     programs.shfmt.enable = true;
+    programs.zizmor.enable = true;
+
     settings.formatter.shfmt.options = [ "--space-redirects" ];
   };
 
@@ -67,6 +69,7 @@ let
         rust-analyzer
         rustfmt
         treefmtEval.config.build.wrapper
+        zizmor
       ];
     };
 

--- a/default.nix
+++ b/default.nix
@@ -59,11 +59,12 @@ let
         cargo-audit
         cargo-edit
         cargo-outdated
+        defaultNixPackage
         npins
+        pinact
         rust-analyzer
         rustfmt
         treefmtEval.config.build.wrapper
-        defaultNixPackage
       ];
     };
 

--- a/default.nix
+++ b/default.nix
@@ -35,8 +35,9 @@ let
     # Used to find the project root
     projectRootFile = "Cargo.toml";
 
-    programs.rustfmt.enable = true;
+    programs.actionlint.enable = true;
     programs.nixfmt.enable = true;
+    programs.rustfmt.enable = true;
     programs.shfmt.enable = true;
     settings.formatter.shfmt.options = [ "--space-redirects" ];
   };
@@ -56,6 +57,7 @@ let
       env.RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
       inputsFrom = [ packages.build ];
       nativeBuildInputs = with pkgs; [
+        actionlint
         cargo-audit
         cargo-edit
         cargo-outdated


### PR DESCRIPTION
Would like to have these in place before working on my grand plans to automate releasing/changelogs. (Spoiler: it's [knope](https://github.com/NixOS/nixpkgs/pull/508140))