### PR TITLE
Automated update

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre985930.01fbdeef22b7/nixexprs.tar.xz",
-      "hash": "sha256-Kq5uL1t/WUp+Z3CjXDpoE9seUiUNLqHN3FkiIjneWeA="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre991389.73c703c22422/nixexprs.tar.xz",
+      "hash": "sha256-bA5oJv7j54PubdUbBlLCwdoK29G2+9sLnc8dDqLQ9YE="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/7hl2hqlqhg2qf27yfksi3zv36rwpdmhp-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 18 packages

```
### cargo update

```
    Updating crates.io index
     Locking 0 packages to latest Rust 1.94.1 compatible versions

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1067 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (101 crate dependencies)

```
</details>
Running /nix/store/axnyf9jlprwjybb0ihnsmnjmryaz9dkr-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.85.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.85.0
    cli | 2026/05/04 21:53:50 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | On branch main
updater | Your branch is up to date with 'origin/main'.
updater | 
updater | nothing to commit, working tree clean
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/04 21:53:53 INFO Starting job processing
updater | 2026/05/04 21:53:53 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/05/04 21:54:05 WARN Could not validate the existence of the 'dependabot' branch: No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/04 21:54:05 INFO Started process PID: 1140 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1140 completed with status: pid 1140 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1148 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1148 completed with status: pid 1148 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1155 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1155 completed with status: pid 1155 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1162 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1162 completed with status: pid 1162 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.02 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1169 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1169 completed with status: pid 1169 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1176 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1176 completed with status: pid 1176 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1183 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1183 completed with status: pid 1183 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1190 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1190 completed with status: pid 1190 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1197 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1197 completed with status: pid 1197 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1204 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1204 completed with status: pid 1204 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1211 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1211 completed with status: pid 1211 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1226 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1226 completed with status: pid 1226 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1234 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1234 completed with status: pid 1234 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1241 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1241 completed with status: pid 1241 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1248 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1248 completed with status: pid 1248 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1255 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1255 completed with status: pid 1255 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1262 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1262 completed with status: pid 1262 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1269 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1269 completed with status: pid 1269 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1276 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1276 completed with status: pid 1276 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1283 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1283 completed with status: pid 1283 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1290 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1290 completed with status: pid 1290 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1297 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1297 completed with status: pid 1297 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1304 with command: {} git rev-parse HEAD {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1304 completed with status: pid 1304 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1319 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1319 completed with status: pid 1319 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1327 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1327 completed with status: pid 1327 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1334 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/04 21:54:05 INFO Process PID: 1334 completed with status: pid 1334 exit 0
updater | 2026/05/04 21:54:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:05 INFO Started process PID: 1341 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1341 completed with status: pid 1341 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1348 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1348 completed with status: pid 1348 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1355 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1355 completed with status: pid 1355 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1363 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1363 completed with status: pid 1363 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.01 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1370 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1370 completed with status: pid 1370 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1377 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1377 completed with status: pid 1377 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1384 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1384 completed with status: pid 1384 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1392 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1392 completed with status: pid 1392 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Started process PID: 1399 with command: {} git rev-parse HEAD {}
updater | 2026/05/04 21:54:06 INFO Process PID: 1399 completed with status: pid 1399 exit 0
updater | 2026/05/04 21:54:06 INFO Total execution time: 0.0 seconds
updater | 2026/05/04 21:54:06 INFO Base commit SHA: 052594228b723c8effe37ad40816f622d7a20281
updater | 2026/05/04 21:54:06 INFO Finished job processing
updater | 2026/05/04 21:54:06 INFO Starting job processing
updater | 2026/05/04 21:54:18 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/04 21:54:18 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/05/04 21:54:18 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/05/04 21:54:18 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon.rb:252:in 'Excon.get'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:209:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:180:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:50:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_medium0'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:407:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:244:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:18 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/04 21:54:18 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/05/04 21:54:51 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/04 21:54:51 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/05/04 21:54:51 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/05/04 21:54:51 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:124:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:111:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/04 21:54:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/04 21:54:51 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/05/04 21:55:29 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/05/04 21:55:29 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/vy5z0p8hlysb4xs11slzig2dm5wi3sy9-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre985930.01fbdeef22b7/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre991389.73c703c22422/nixexprs.tar.xz
-    hash: sha256-Kq5uL1t/WUp+Z3CjXDpoE9seUiUNLqHN3FkiIjneWeA=
+    hash: sha256-bA5oJv7j54PubdUbBlLCwdoK29G2+9sLnc8dDqLQ9YE=
[INFO ] Update successful.
```
</details>
