### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -287,7 +287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre991389.73c703c22422/nixexprs.tar.xz",
-      "hash": "sha256-bA5oJv7j54PubdUbBlLCwdoK29G2+9sLnc8dDqLQ9YE="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre995785.c6e5ca3c836a/nixexprs.tar.xz",
+      "hash": "sha256-UuHF8sb6WETWb7HPfOvOVXTAl7UX0VAoxM0Our8WFK0="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/2wlnw36p08i5cz6cwzdq0k2p7xzrgiin-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 18 packages

```
### cargo update

```
    Updating crates.io index
     Locking 1 package to latest Rust 1.94.1 compatible version
    Updating hashbrown v0.17.0 -> v0.17.1

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1069 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (101 crate dependencies)

```
</details>
Running /nix/store/wp31snnbfwydy7pir0fyfixvhgrh3jk7-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.85.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.85.0
    cli | 2026/05/11 15:48:49 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/11 15:48:52 INFO Starting job processing
updater | 2026/05/11 15:48:52 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/05/11 15:49:04 WARN Could not validate the existence of the 'dependabot' branch: No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/11 15:49:04 INFO Started process PID: 1142 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1142 completed with status: pid 1142 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1150 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1150 completed with status: pid 1150 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1157 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1157 completed with status: pid 1157 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1164 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.02 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1171 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1171 completed with status: pid 1171 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1178 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1178 completed with status: pid 1178 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1185 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1185 completed with status: pid 1185 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1192 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1192 completed with status: pid 1192 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1199 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1199 completed with status: pid 1199 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1206 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1206 completed with status: pid 1206 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1213 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1213 completed with status: pid 1213 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1228 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1228 completed with status: pid 1228 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.01 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1236 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1236 completed with status: pid 1236 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1243 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1243 completed with status: pid 1243 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1250 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1250 completed with status: pid 1250 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1257 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/11 15:49:04 INFO Process PID: 1257 completed with status: pid 1257 exit 0
updater | 2026/05/11 15:49:04 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:04 INFO Started process PID: 1264 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1264 completed with status: pid 1264 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1273 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1273 completed with status: pid 1273 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1280 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1280 completed with status: pid 1280 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1287 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1287 completed with status: pid 1287 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1294 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1294 completed with status: pid 1294 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1301 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1301 completed with status: pid 1301 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1308 with command: {} git rev-parse HEAD {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1308 completed with status: pid 1308 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1323 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1323 completed with status: pid 1323 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1331 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1331 completed with status: pid 1331 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1338 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1338 completed with status: pid 1338 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1345 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1345 completed with status: pid 1345 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1352 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1352 completed with status: pid 1352 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1359 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1359 completed with status: pid 1359 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.01 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1366 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1366 completed with status: pid 1366 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.01 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1373 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1373 completed with status: pid 1373 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.01 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1380 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1380 completed with status: pid 1380 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1387 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1387 completed with status: pid 1387 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.01 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1394 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1394 completed with status: pid 1394 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Started process PID: 1401 with command: {} git rev-parse HEAD {}
updater | 2026/05/11 15:49:05 INFO Process PID: 1401 completed with status: pid 1401 exit 0
updater | 2026/05/11 15:49:05 INFO Total execution time: 0.0 seconds
updater | 2026/05/11 15:49:05 INFO Base commit SHA: 4b857f76a05f13f3689cb0e2c4eb3d07e9dcee71
updater | 2026/05/11 15:49:05 INFO Finished job processing
updater | 2026/05/11 15:49:05 INFO Starting job processing
updater | 2026/05/11 15:49:17 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/11 15:49:17 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/05/11 15:49:17 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/05/11 15:49:17 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon.rb:252:in 'Excon.get'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:209:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:180:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:50:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_medium0'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:407:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:244:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:17 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/11 15:49:17 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/05/11 15:49:51 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/11 15:49:51 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/05/11 15:49:51 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/05/11 15:49:51 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:124:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:111:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/11 15:49:51 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/11 15:49:51 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/05/11 15:50:22 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/05/11 15:50:23 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/nwsffkzbdardalz60d35zb7ipc3c7fln-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre991389.73c703c22422/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre995785.c6e5ca3c836a/nixexprs.tar.xz
-    hash: sha256-bA5oJv7j54PubdUbBlLCwdoK29G2+9sLnc8dDqLQ9YE=
+    hash: sha256-UuHF8sb6WETWb7HPfOvOVXTAl7UX0VAoxM0Our8WFK0=
[INFO ] Update successful.
```
</details>
