### PR TITLE
Automated update

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre995785.c6e5ca3c836a/nixexprs.tar.xz",
-      "hash": "sha256-UuHF8sb6WETWb7HPfOvOVXTAl7UX0VAoxM0Our8WFK0="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre998534.d233902339c0/nixexprs.tar.xz",
+      "hash": "sha256-vZOcDniDPc1cS8A4Xi5YE6AGyPIvEpy4GMyayA3SWIM="
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Running /nix/store/2wlnw36p08i5cz6cwzdq0k2p7xzrgiin-cargo
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 18 packages

```
### cargo update

```
    Updating crates.io index
     Locking 0 packages to latest Rust 1.94.1 compatible versions

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1090 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (101 crate dependencies)

```
</details>
Running /nix/store/wz74ckbsgm9skszc8qaw661daynfkm40-update-github-actions
<details><summary>GitHub Action updates</summary>

Loaded image: dependabot-update-job-proxy:nixpkgs-dependabot-cli-1.85.0
Loaded image: dependabot-updater-github-actions:nixpkgs-dependabot-cli-1.85.0
    cli | 2026/05/18 16:00:03 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
  proxy | sh: /dependabot-proxy: not found
updater | Reinitialized existing Git repository in /home/dependabot/dependabot-updater/repo/.git/
updater | On branch main
updater | Your branch is up to date with 'origin/main'.
updater | 
updater | nothing to commit, working tree clean
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/18 16:00:06 INFO Starting job processing
updater | 2026/05/18 16:00:06 INFO Job definition: {"job":{"command":"update","package-manager":"github_actions","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[{"name":"actions","rules":{"patterns":["*"]}}],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"not/used","directory":"/","hostname":null,"api-endpoint":null},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":0,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/05/18 16:00:18 WARN Could not validate the existence of the 'dependabot' branch: No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/18 16:00:18 INFO Started process PID: 1142 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1142 completed with status: pid 1142 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.01 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1150 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1150 completed with status: pid 1150 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1157 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1157 completed with status: pid 1157 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1164 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.02 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1171 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1171 completed with status: pid 1171 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1178 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1178 completed with status: pid 1178 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1185 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1185 completed with status: pid 1185 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1192 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1192 completed with status: pid 1192 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1199 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1199 completed with status: pid 1199 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1206 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1206 completed with status: pid 1206 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1213 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1213 completed with status: pid 1213 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1229 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1229 completed with status: pid 1229 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1237 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1237 completed with status: pid 1237 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1244 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1244 completed with status: pid 1244 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1251 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1251 completed with status: pid 1251 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1258 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1258 completed with status: pid 1258 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1265 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1265 completed with status: pid 1265 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1272 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1272 completed with status: pid 1272 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1279 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1279 completed with status: pid 1279 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.01 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1286 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1286 completed with status: pid 1286 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1293 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1293 completed with status: pid 1293 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1300 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1300 completed with status: pid 1300 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1307 with command: {} git rev-parse HEAD {}
updater | 2026/05/18 16:00:18 INFO Process PID: 1307 completed with status: pid 1307 exit 0
updater | 2026/05/18 16:00:18 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:18 INFO Started process PID: 1322 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1322 completed with status: pid 1322 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1330 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1330 completed with status: pid 1330 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1337 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1337 completed with status: pid 1337 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1344 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1344 completed with status: pid 1344 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1351 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1351 completed with status: pid 1351 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1358 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1358 completed with status: pid 1358 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1365 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1365 completed with status: pid 1365 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1372 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1372 completed with status: pid 1372 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1379 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1379 completed with status: pid 1379 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1386 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1386 completed with status: pid 1386 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.0 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1393 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1393 completed with status: pid 1393 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.01 seconds
updater | 2026/05/18 16:00:19 INFO Started process PID: 1400 with command: {} git rev-parse HEAD {}
updater | 2026/05/18 16:00:19 INFO Process PID: 1400 completed with status: pid 1400 exit 0
updater | 2026/05/18 16:00:19 INFO Total execution time: 0.01 seconds
updater | 2026/05/18 16:00:19 INFO Base commit SHA: b016e6f9b9945a9c9248cd2026962ef72bd5e3d8
updater | 2026/05/18 16:00:19 INFO Finished job processing
updater | 2026/05/18 16:00:19 INFO Starting job processing
updater | 2026/05/18 16:00:31 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/18 16:00:31 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/05/18 16:00:31 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/05/18 16:00:31 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:194:in 'Excon::SSLSocket#connect'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/ssl_socket.rb:10:in 'Excon::SSLSocket#initialize'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Class#new'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:487:in 'Excon::Connection#socket'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:50:in 'Excon::Middleware::Idempotent#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:17:in 'Excon::Middleware::Base#error_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:322:in 'Excon::Connection#request'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon.rb:252:in 'Excon.get'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:209:in 'Dependabot::GitMetadataFetcher#fetch_raw_upload_pack_for'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:180:in 'Dependabot::GitMetadataFetcher#fetch_upload_pack_for'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:108:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_fast1'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:50:in 'Dependabot::GitMetadataFetcher#upload_pack'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::GitMetadataFetcher#create_validator_method_medium0'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:407:in 'Dependabot::GitCommitChecker#local_upload_pack'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/common/lib/dependabot/git_commit_checker.rb:244:in 'Dependabot::GitCommitChecker#git_repo_reachable?'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GitCommitChecker#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:74:in 'block in Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Array#each'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:63:in 'Dependabot::GithubActions::FileParser#workfile_file_dependencies'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:30:in 'block in Dependabot::GithubActions::FileParser#parse'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Array#each'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/github_actions/lib/dependabot/github_actions/file_parser.rb:29:in 'Dependabot::GithubActions::FileParser#parse'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::GithubActions::FileParser#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:274:in 'Dependabot::DependencySnapshot#parse_files!'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:232:in 'block in Dependabot::DependencySnapshot#initialize'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Array#each'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:230:in 'Dependabot::DependencySnapshot#initialize'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Class#new'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:31:in 'Dependabot::DependencySnapshot.create_from_job_definition'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::DependencySnapshot._on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:34:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:00:31 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/18 16:00:31 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/05/18 16:01:06 ERROR No route to host - connect(2) for 172.18.0.2:1080 (Errno::EHOSTUNREACH)
updater | 2026/05/18 16:01:06 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#__connect_nonblock'
updater | 2026/05/18 16:01:06 ERROR /usr/local/lib/ruby/3.4.0/socket.rb:1639:in 'Socket#connect_nonblock'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:176:in 'block in Excon::Socket#connect'
updater | 2026/05/18 16:01:06 ERROR /usr/local/lib/ruby/3.4.0/resolv.rb:122:in 'Resolv#each_address'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:145:in 'Excon::Socket#connect'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/socket.rb:60:in 'Excon::Socket#initialize'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Class#new'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:489:in 'Excon::Connection#socket'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:120:in 'Excon::Connection#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/redirect_follower.rb:15:in 'Excon::Middleware::RedirectFollower#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/mock.rb:57:in 'Excon::Middleware::Mock#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:31:in 'block in Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/common/lib/dependabot/simple_instrumentor.rb:35:in 'Dependabot::SimpleInstrumentor.instrument'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:203:in 'block in Dependabot::SimpleInstrumentor.create_validator_slow'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/instrumentor.rb:30:in 'Excon::Middleware::Instrumentor#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/idempotent.rb:19:in 'Excon::Middleware::Idempotent#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/decompress.rb:14:in 'Excon::Middleware::Decompress#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/middlewares/base.rb:22:in 'Excon::Middleware::Base#request_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:293:in 'Excon::Connection#request'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/excon-1.3.2/lib/excon/connection.rb:379:in 'Excon::Connection#post'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:124:in 'block in Dependabot::ApiClient#record_update_job_error'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:111:in 'Dependabot::ApiClient#record_update_job_error'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::ApiClient#_on_method_added'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:90:in 'Dependabot::Service#record_update_job_error'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::Service#_on_method_added'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:137:in 'Dependabot::UpdateFilesCommand#handle_parser_error'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.7.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/_methods.rb:259:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/18 16:01:06 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12977/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/18 16:01:06 ERROR bin/update_files.rb:48:in '<main>'
updater | 2026/05/18 16:01:36 INFO Results:
updater | Dependabot encountered '2' error(s) during execution, please check the logs for more details.
updater | +--------------------+
updater | |       Errors       |
updater | +--------------------+
updater | | update_files_error |
updater | | unknown_error      |
updater | +--------------------+
    cli | 2026/05/18 16:01:37 updater failure: proxy container exited with non-zero exit code: 127
</details>
Running /nix/store/1ld86cj2mmdr7fc7dqylkbpl21jd549r-update-npins
<details><summary>npins changes</summary>

```
[treefmt-nix] No Changes
[nixpkgs] Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre995785.c6e5ca3c836a/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre998534.d233902339c0/nixexprs.tar.xz
-    hash: sha256-UuHF8sb6WETWb7HPfOvOVXTAl7UX0VAoxM0Our8WFK0=
+    hash: sha256-vZOcDniDPc1cS8A4Xi5YE6AGyPIvEpy4GMyayA3SWIM=
[INFO ] Update successful.
```
</details>
