### PR TITLE
ci: remove unsupported versioning-strategy value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    versioning-strategy: "increase"
     groups:
       cargo:
         patterns:


### PR DESCRIPTION
`increase` isn't supported for Cargo, apparently. (This is not reflected anywhere in the docs, of course.)