### PR TITLE
ci: don't fail after merging non-changelog-entry-creating changes

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -8,7 +8,9 @@ repo = "nixpkgs-vet"
 
 [release_notes]
 change_templates = [
+    "### $summary (#$pr_number)\n\n$details\n\nBy @$pr_author_login",
     "### $summary ($commit_hash)\n\n$details\n\nBy $commit_author_name",
+    "* **$summary** by @$pr_author_login (#$pr_number)",
     "* **$summary** by $commit_author_name ($commit_hash)",
     "### $summary\n\n$details",
     "* **$summary**",

--- a/knope.toml
+++ b/knope.toml
@@ -31,6 +31,7 @@ command = "git switch -c release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
+allow_empty = true
 
 [[workflows.steps]]
 type = "Command"


### PR DESCRIPTION
Also update the changelog templates with the newly supported ability to use the PR number and GitHub login.

Config info: https://knope.tech/reference/config-file/steps/prepare-release/#options, https://knope.tech/reference/config-file/release-notes/