### PR TITLE
Ignore ineffective package attrs in `strictDeps` & `__structuredAttrs` checks

### DIFF
--- a/.changeset/ignore_ineffective_package_attrs_in_strictdeps_structuredattrs_checks.md
+++ b/.changeset/ignore_ineffective_package_attrs_in_strictdeps_structuredattrs_checks.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Ignore ineffective package attrs in `strictDeps` & `__structuredAttrs` checks
+
+Previously, setting e.g. `passthru.__structuredAttrs` would satisfy our checks, even though this is not effective to actually enable `__structuredAttrs` in the derivation.
+
+Detection of these features now more closely aligns with the actual derivation's use of them.

--- a/src/eval.nix
+++ b/src/eval.nix
@@ -58,6 +58,10 @@ let
         { NonAttributeSet = null; }
       else
         let
+          # Not all attrs (or even all derivations) have an `overrideAttrs`,
+          # only those constructed by something based on `stdenv.mkDerivation`
+          overrideValue = value.overrideAttrs or (_: value);
+
           # Disallows people getting around actually setting `strictDeps`
           # and `__structuredAttrs` by doing something like:
           # {
@@ -67,20 +71,14 @@ let
           # package = package-final // {
           #   __structuredAttrs = true;
           # };
-          cleanPackage =
-            if value ? overrideAttrs then
-              value.overrideAttrs (
-                _: prev: {
-                  passthru = removeAttrs (prev.passthru or { }) [
-                    "__structuredAttrs"
-                    "strictDeps"
-                  ];
-                }
-              )
-            else if pkgs.lib.isDerivation value then
-              throw "${name} derivation is missing overrideAttrs"
-            else
-              value;
+          cleanPackage = overrideValue (
+            _: prev: {
+              passthru = removeAttrs (prev.passthru or { }) [
+                "__structuredAttrs"
+                "strictDeps"
+              ];
+            }
+          );
         in
         {
           AttributeSet = {

--- a/src/eval.nix
+++ b/src/eval.nix
@@ -57,11 +57,30 @@ let
       if !builtins.isAttrs value then
         { NonAttributeSet = null; }
       else
+        let
+          # Disallows people getting around actually setting `strictDeps`
+          # and `__structuredAttrs` by doing something like:
+          # {
+          #   passthru.strictDeps = true;
+          # }
+          # or
+          # package = package-final // {
+          #   __structuredAttrs = true;
+          # };
+          cleanPackage = value.overrideAttrs (
+            _: prev: {
+              passthru = removeAttrs (prev.passthru or { }) [
+                "__structuredAttrs"
+                "strictDeps"
+              ];
+            }
+          );
+        in
         {
           AttributeSet = {
             is_derivation = pkgs.lib.isDerivation value;
-            strict_deps = value.strictDeps or false;
-            structured_attrs = value.__structuredAttrs or false;
+            strict_deps = cleanPackage.strictDeps or false;
+            structured_attrs = cleanPackage.__structuredAttrs or false;
             definition_variant =
               if !value ? _callPackageVariant then
                 { ManualDefinition.is_semantic_call_package = false; }

--- a/src/eval.nix
+++ b/src/eval.nix
@@ -67,14 +67,20 @@ let
           # package = package-final // {
           #   __structuredAttrs = true;
           # };
-          cleanPackage = value.overrideAttrs (
-            _: prev: {
-              passthru = removeAttrs (prev.passthru or { }) [
-                "__structuredAttrs"
-                "strictDeps"
-              ];
-            }
-          );
+          cleanPackage =
+            if value ? overrideAttrs then
+              value.overrideAttrs (
+                _: prev: {
+                  passthru = removeAttrs (prev.passthru or { }) [
+                    "__structuredAttrs"
+                    "strictDeps"
+                  ];
+                }
+              )
+            else if pkgs.lib.isDerivation value then
+              throw "${name} derivation is missing overrideAttrs"
+            else
+              value;
         in
         {
           AttributeSet = {

--- a/tests/mock-nixpkgs.nix
+++ b/tests/mock-nixpkgs.nix
@@ -41,11 +41,13 @@ let
     # By using `mapAttrs`, `builtins.unsafeGetAttrPos` just returns `null`,
     # which then doesn't trigger this check
     // lib.mapAttrs (name: value: value) {
-      someDrv = {
-        type = "derivation";
-        strictDeps = true;
-        __structuredAttrs = true;
-      };
+      someDrv = (
+        lib.makeExtensibleWithCustomName "overrideAttrs" (finalAttrs: {
+          type = "derivation";
+          strictDeps = true;
+          __structuredAttrs = true;
+        })
+      );
     };
 
   baseDirectory = root + "/pkgs/by-name";

--- a/tests/mock-nixpkgs.nix
+++ b/tests/mock-nixpkgs.nix
@@ -33,6 +33,15 @@ let
       newScope = extra: lib.callPackageWith (self // extra);
       callPackage = self.newScope { };
       callPackages = lib.callPackagesWith self;
+      mkFakeDrv =
+        args:
+        lib.makeExtensibleWithCustomName "overrideAttrs" (
+          finalAttrs:
+          {
+            type = "derivation";
+          }
+          // args finalAttrs
+        );
     }
     # This mapAttrs is a very hacky workaround necessary because for all attributes defined in Nixpkgs,
     # the files that define them are verified to be within Nixpkgs.
@@ -41,13 +50,10 @@ let
     # By using `mapAttrs`, `builtins.unsafeGetAttrPos` just returns `null`,
     # which then doesn't trigger this check
     // lib.mapAttrs (name: value: value) {
-      someDrv = (
-        lib.makeExtensibleWithCustomName "overrideAttrs" (finalAttrs: {
-          type = "derivation";
-          strictDeps = true;
-          __structuredAttrs = true;
-        })
-      );
+      someDrv = self.mkFakeDrv (finalAttrs: {
+        strictDeps = true;
+        __structuredAttrs = true;
+      });
     };
 
   baseDirectory = root + "/pkgs/by-name";

--- a/tests/new-plain-derivation-strict-deps-unset/expected
+++ b/tests/new-plain-derivation-strict-deps-unset/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `strictDeps` unset or set to `false`.
+  Please enable `strictDeps = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-164)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/new-plain-derivation-strict-deps-unset/main/default.nix
+++ b/tests/new-plain-derivation-strict-deps-unset/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/new-plain-derivation-strict-deps-unset/main/pkgs/by-name/README.md
+++ b/tests/new-plain-derivation-strict-deps-unset/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/new-plain-derivation-strict-deps-unset/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/new-plain-derivation-strict-deps-unset/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,7 @@
+{ }:
+# A "plain" derivation without `overrideAttrs`
+{
+  type = "derivation";
+  __structuredAttrs = true;
+  # No strictDeps
+}

--- a/tests/new-plain-derivation-structured-attrs-unset/expected
+++ b/tests/new-plain-derivation-structured-attrs-unset/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `__structuredAttrs` unset or set to `false`.
+  Please enable `__structuredAttrs = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-166)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/new-plain-derivation-structured-attrs-unset/main/default.nix
+++ b/tests/new-plain-derivation-structured-attrs-unset/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/new-plain-derivation-structured-attrs-unset/main/pkgs/by-name/README.md
+++ b/tests/new-plain-derivation-structured-attrs-unset/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/new-plain-derivation-structured-attrs-unset/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/new-plain-derivation-structured-attrs-unset/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,7 @@
+{ }:
+# A "plain" derivation without `overrideAttrs`
+{
+  type = "derivation";
+  # No __structuredAttrs
+  strictDeps = true;
+}

--- a/tests/new-plain-derivation/expected
+++ b/tests/new-plain-derivation/expected
@@ -1,0 +1,1 @@
+Validated successfully

--- a/tests/new-plain-derivation/main/default.nix
+++ b/tests/new-plain-derivation/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/new-plain-derivation/main/pkgs/by-name/README.md
+++ b/tests/new-plain-derivation/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/new-plain-derivation/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/new-plain-derivation/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,7 @@
+{ }:
+# A "plain" derivation without `overrideAttrs`
+{
+  type = "derivation";
+  __structuredAttrs = true;
+  strictDeps = true;
+}

--- a/tests/strict-deps-new-false/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-false/main/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,1 @@
-{ someDrv }: someDrv // { strictDeps = false; }
+{ someDrv }: someDrv.overrideAttrs (_: _: { strictDeps = false; })

--- a/tests/strict-deps-new-passthru/expected
+++ b/tests/strict-deps-new-passthru/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `strictDeps` unset or set to `false`.
+  Please enable `strictDeps = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-164)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/strict-deps-new-passthru/main/default.nix
+++ b/tests/strict-deps-new-passthru/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/strict-deps-new-passthru/main/pkgs/by-name/README.md
+++ b/tests/strict-deps-new-passthru/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/strict-deps-new-passthru/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-passthru/main/pkgs/by-name/fo/foo/package.nix
@@ -1,6 +1,8 @@
-{ someDrv }:
-someDrv
+{ mkFakeDrv }:
+mkFakeDrv (finalAttrs: {
+  __structuredAttrs = true;
+  # No strictDeps
+})
 // {
   strictDeps = true;
-  drvAttrs = removeAttrs someDrv.drvAttrs [ "strictDeps" ];
 }

--- a/tests/strict-deps-new-passthru/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-passthru/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,6 @@
+{ someDrv }:
+someDrv
+// {
+  strictDeps = true;
+  drvAttrs = removeAttrs someDrv.drvAttrs [ "strictDeps" ];
+}

--- a/tests/strict-deps-new-unset/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-new-unset/main/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,5 @@
-{ someDrv }: removeAttrs someDrv [ "strictDeps" ]
+{ mkFakeDrv }:
+mkFakeDrv (finalAttrs: {
+  __structuredAttrs = true;
+  # No strictDeps
+})

--- a/tests/strict-deps-regression/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/strict-deps-regression/main/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,1 @@
-{ someDrv }: someDrv // { strictDeps = false; }
+{ someDrv }: someDrv.overrideAttrs (_: _: { strictDeps = false; })

--- a/tests/structured-attrs-new-false/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-false/main/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,1 @@
-{ someDrv }: someDrv // { __structuredAttrs = false; }
+{ someDrv }: someDrv.overrideAttrs (_: _: { __structuredAttrs = false; })

--- a/tests/structured-attrs-new-passthru/expected
+++ b/tests/structured-attrs-new-passthru/expected
@@ -1,0 +1,4 @@
+- Attribute `pkgs.foo` is a new package with `__structuredAttrs` unset or set to `false`.
+  Please enable `__structuredAttrs = true;` in pkgs/by-name/fo/foo/package.nix.
+ (https://github.com/NixOS/nixpkgs-vet/wiki/NPV-166)
+This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.

--- a/tests/structured-attrs-new-passthru/main/default.nix
+++ b/tests/structured-attrs-new-passthru/main/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/tests/structured-attrs-new-passthru/main/pkgs/by-name/README.md
+++ b/tests/structured-attrs-new-passthru/main/pkgs/by-name/README.md
@@ -1,0 +1,1 @@
+# Test fixture

--- a/tests/structured-attrs-new-passthru/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-passthru/main/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,6 @@
+{ someDrv }:
+someDrv
+// {
+  __structuredAttrs = true;
+  drvAttrs = removeAttrs someDrv.drvAttrs [ "__structuredAttrs" ];
+}

--- a/tests/structured-attrs-new-passthru/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-passthru/main/pkgs/by-name/fo/foo/package.nix
@@ -1,6 +1,8 @@
-{ someDrv }:
-someDrv
+{ mkFakeDrv }:
+mkFakeDrv (finalAttrs: {
+  strictDeps = true;
+  # No __structuredAttrs
+})
 // {
   __structuredAttrs = true;
-  drvAttrs = removeAttrs someDrv.drvAttrs [ "__structuredAttrs" ];
 }

--- a/tests/structured-attrs-new-unset/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-new-unset/main/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,5 @@
-{ someDrv }: removeAttrs someDrv [ "__structuredAttrs" ]
+{ mkFakeDrv }:
+mkFakeDrv (finalAttrs: {
+  strictDeps = true;
+  # No __structuredAttrs
+})

--- a/tests/structured-attrs-regression/main/pkgs/by-name/fo/foo/package.nix
+++ b/tests/structured-attrs-regression/main/pkgs/by-name/fo/foo/package.nix
@@ -1,1 +1,1 @@
-{ someDrv }: someDrv // { __structuredAttrs = false; }
+{ someDrv }: someDrv.overrideAttrs (_: _: { __structuredAttrs = false; })


### PR DESCRIPTION
Closes #263 

For `strictDeps` and `structuredAttrs` to be effectively set, they must go through `stdenv`'s machinery. The direct way of checking that would be something like 
```
> nix derivation show -f. hello | jq '((.[].env.strictDeps // "0") == "1") or (.[].env.__json | fromjson | .strictDeps)'
```
and
```
> nix derivation show -f. hello | jq '.[].env | has("__json")'
```
Since I don't want to change everything to do that, this is the next best thing. Without these checks people can write:
```nix
stdenv.mkDerivation {
  passthru = {
    strictDeps = true;
    __structuredAttrs = true;
  };
}
```
And the check will pass. Alternatively:
```nix
package-final = package // {
  strictDeps = true;
  __structuredAttrs = true;
};
```
and tests will pass. ~~What this cannot guard against is people writing:~~
```nix
package-final = package // {
  drvAttrs = package.drvAttrs // {
    strictDeps = true;
    __structuredAttrs = true;
  };
}
```
~~and vet passing.~~ But hopefully this will look weird enough that it will be caught in review. But I would've thought the same for the latter ones and they weren't immediately caught. 


Codebase could use some documentation on what arguments do and such, as it took me a bit and still don't completely get it. But tests pass 😎 👍 