### PR TITLE
ci: stop xrefcheck flaking on qntm.org timeouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,5 +150,4 @@ jobs:
       - uses: serokell/xrefcheck-action@81d3967156933307f52fc52f8dc7fa5e947509c2 # v1.0.3
         with: # Invalid symlinks for testing purposes.
           xrefcheck-args: >
-            --ignore tests/top-level/symlink-invalid/main/pkgs/by-name/fo/foo/foo
-            --ignore tests/top-level/multiple-failures/main/pkgs/by-name/A/fo@/foo
+            --config .github/xrefcheck.yaml

--- a/.github/xrefcheck.yaml
+++ b/.github/xrefcheck.yaml
@@ -1,0 +1,111 @@
+# Exclusion parameters.
+exclusions:
+  # Ignore these files. References to them will fail verification,
+  # and references from them will not be verified.
+  # List of glob patterns.
+  ignore: []
+
+  # References from these files will not be verified.
+  # List of glob patterns.
+  ignoreRefsFrom:
+    - .github/pull_request_template.md
+    - .github/issue_template.md
+    - .github/PULL_REQUEST_TEMPLATE/**/*
+    - .github/ISSUE_TEMPLATE/**/*
+    - tests/top-level/symlink-invalid/main/pkgs/by-name/fo/foo/foo
+    - tests/top-level/multiple-failures/main/pkgs/by-name/A/fo@/foo
+
+  # References to these paths will not be verified.
+  # List of glob patterns.
+  ignoreLocalRefsTo:
+    - ../../../issues
+    - ../../../issues/*
+    - ../../../pulls
+    - ../../../pulls/*
+
+  # References to these URIs will not be verified.
+  # List of POSIX extended regular expressions.
+  ignoreExternalRefsTo:
+    # Ignore localhost links by default
+    - (https?|ftps?)://(localhost|127\.0\.0\.1).*
+    # qntm.org is up, but times out often enough from GitHub runners to make CI flaky.
+    - https://qntm\.org/.*
+
+# Networking parameters.
+networking:
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
+  # Skip links which return 403 or 401 code.
+  ignoreAuthFailures: true
+
+  # When a verification result is a "429 Too Many Requests" response
+  # and it does not contain a "Retry-After" header,
+  # wait this amount of time before attempting to verify the link again.
+  defaultRetryAfter: 30s
+
+  # How many attempts to retry an external link after getting
+  # a "429 Too Many Requests" response.
+  # Timeouts may also be accounted here, see the description
+  # of `maxTimeoutRetries` field.
+
+  # If a site once responded with 429 error code, subsequent
+  # request timeouts will also be treated as hitting the site's
+  # rate limiter and result in retry attempts, unless the
+  # maximum retries number has been reached.
+  #
+  # On other errors xrefcheck fails immediately, without retrying.
+  maxRetries: 3
+
+  # Querying a given domain that ever returned 429 before,
+  # this defines how many timeouts are allowed during retries.
+  #
+  # For such domains, timeouts likely mean hitting the rate limiter,
+  # and so xrefcheck considers timeouts in the same way as 429 errors.
+  #
+  # For other domains, a timeout results in a respective error, no retry
+  # attempts will be performed. Use `externalRefCheckTimeout` option
+  # to increase the time after which timeout is declared.
+  #
+  # This option is similar to `maxRetries`, the difference is that
+  # this `maxTimeoutRetries` option limits only the number of retries
+  # caused by timeouts, and `maxRetries` limits the number of retries
+  # caused both by 429s and timeouts.
+  maxTimeoutRetries: 1
+
+  # Maximum number of links that can be followed in a single redirect
+  # chain.
+  #
+  # The link is considered as invalid if the limit is exceeded.
+  maxRedirectFollows: 10
+
+  # Rules to override the redirect behavior for external references that
+  # match, where
+  #   - 'from' is a regular expression for the source link in a single
+  #     redirection step. Its absence means that every link matches.
+  #   - 'to' is a regular expression for the target link in a single
+  #     redirection step. Its absence also means that every link matches.
+  #   - 'on' accepts 'temporary', 'permanent' or a specific redirect HTTP code.
+  #     Its absence also means that every response code matches.
+  #   - 'outcome' accepts 'valid', 'invalid' or 'follow'. The last one follows
+  #      the redirect by applying the same configuration rules so, for instance,
+  #      exclusion rules would also apply to the following links.
+  #
+  # The first one that matches is applied, and the link is considered
+  # as valid if none of them does match.
+  externalRefRedirects:
+    - on: permanent
+      outcome: invalid
+
+# Parameters of scanners for various file types.
+scanners:
+  # On 'anchor not found' error, how much similar anchors should be displayed as
+  # hint. Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
+  markdown:
+    # Flavor of markdown, e.g. GitHub-flavor.
+    #
+    # This affects which anchors are generated for headers.
+    flavor: GitHub


### PR DESCRIPTION
Every recent dependabot PR has failed the xrefcheck job with "Response timeout" on https://qntm.org/ratchet, even though the site is up; it just responds slowly or rate-limits GitHub runners.

Add an xrefcheck config (generated with `xrefcheck dump-config -t GitHub`, kept out of the repo root under `.github/`) that excludes qntm.org from external link verification, and pass it via `--config`.